### PR TITLE
fix(@m3e/snackbar): fix global variable type declaration

### DIFF
--- a/packages/web/src/snackbar/Snackbar.ts
+++ b/packages/web/src/snackbar/Snackbar.ts
@@ -127,9 +127,12 @@ export class M3eSnackbar {
   }
 }
 
+// This is the class type, as opposed to an instance of the class.
+type M3eSnackbarClass = typeof M3eSnackbar;
+
 declare global {
   /** Presents short updates about application processes at the bottom of the screen from anywhere in an application. */
-  var M3eSnackbar: M3eSnackbar;
+  var M3eSnackbar: M3eSnackbarClass;
 }
 
 globalThis.M3eSnackbar = M3eSnackbar;


### PR DESCRIPTION
## Description

globalThis.M3eSnackbar is the class itself (`typeof M3eSnackbar`) and not an instance of the class (`M3eSnackbar`).

Before this commit, Typescript would for instance complain that `open` is not a method of `globalThis.M3eSnackbar`. This commit fixes this.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published