### PR TITLE
Feature/handling SSR and hydration errors in Next js.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -81,6 +82,7 @@
       "version": "6.3.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -104,6 +106,7 @@
       "version": "7.27.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.27.2",
         "@babel/helper-validator-option": "^7.27.1",
@@ -119,6 +122,7 @@
       "version": "5.1.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -127,6 +131,7 @@
       "version": "6.3.1",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -155,6 +160,7 @@
       "version": "7.28.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -187,6 +193,7 @@
       "version": "7.27.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -195,6 +202,7 @@
       "version": "7.28.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.27.2",
         "@babel/types": "^7.28.4"
@@ -438,8 +446,7 @@
     },
     "node_modules/@floating-ui/utils": {
       "version": "0.2.10",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@github/catalyst": {
       "version": "1.7.0",
@@ -503,6 +510,7 @@
       "version": "2.3.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -541,7 +549,8 @@
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.4.0",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@lit/react": {
       "version": "1.0.8",
@@ -554,6 +563,7 @@
     "node_modules/@lit/reactive-element": {
       "version": "2.1.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.4.0"
       }
@@ -1108,7 +1118,8 @@
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.44.0",
@@ -1150,7 +1161,6 @@
       "version": "8.44.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -1509,7 +1519,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1673,7 +1682,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1844,7 +1852,8 @@
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1861,7 +1870,8 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/custom-element-vs-code-integration": {
       "version": "1.5.0",
@@ -1958,7 +1968,6 @@
       "version": "9.36.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2248,6 +2257,7 @@
       "version": "1.0.0-beta.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2584,6 +2594,7 @@
       "version": "2.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -2624,6 +2635,7 @@
     "node_modules/lit-element": {
       "version": "4.2.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.4.0",
         "@lit/reactive-element": "^2.1.0",
@@ -2633,6 +2645,7 @@
     "node_modules/lit-html": {
       "version": "3.3.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -3071,7 +3084,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -3315,8 +3327,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "dev": true,
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -3333,7 +3344,6 @@
       "version": "5.8.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3434,7 +3444,8 @@
     "node_modules/yallist": {
       "version": "3.1.1",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -3462,7 +3473,6 @@
       "name": "@m3e/web",
       "version": "2.0.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.6.13",
         "@material/material-color-utilities": "^0.3.0",

--- a/packages/react/src/app-bar/AppBar.ts
+++ b/packages/react/src/app-bar/AppBar.ts
@@ -17,8 +17,11 @@ export type { AppBarSize, M3eAppBarElement } from "@m3e/web/app-bar";
  * See the `m3e-app-bar` documentation in `@m3e/app-bar` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eAppBar = createComponent({
+
+const isBrowser = typeof window !== "undefined";
+
+export const M3eAppBar = isBrowser ? createComponent({
   tagName: "m3e-app-bar",
   elementClass: M3eAppBarElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/autocomplete/Autocomplete.ts
+++ b/packages/react/src/autocomplete/Autocomplete.ts
@@ -17,11 +17,17 @@ export type { M3eAutocompleteElement } from "@m3e/web/autocomplete";
  * See the `m3e-autocomplete` documentation in `@m3e/autocomplete` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eAutocomplete = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eAutocomplete = isBrowser ? createComponent({
   tagName: "m3e-autocomplete",
   elementClass: M3eAutocompleteElement,
   react: React,
   events: {
     onToggle: "toggle",
   },
-});
+}) : null;

--- a/packages/react/src/avatar/Avatar.ts
+++ b/packages/react/src/avatar/Avatar.ts
@@ -16,8 +16,14 @@ export type { M3eAvatarElement } from "@m3e/web/avatar";
  * See the `m3e-avatar` documentation in `@m3e/avatar` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eAvatar = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eAvatar = isBrowser ? createComponent({
   tagName: "m3e-avatar",
   elementClass: M3eAvatarElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/badge/Badge.ts
+++ b/packages/react/src/badge/Badge.ts
@@ -17,8 +17,14 @@ export type { BadgeSize, BadgePosition, M3eBadgeElement } from "@m3e/web/badge";
  * See the `m3e-badge` documentation in `@m3e/badge` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eBadge = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eBadge = isBrowser ? createComponent({
   tagName: "m3e-badge",
   elementClass: M3eBadgeElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/bottom-sheet/BottomSheet.ts
+++ b/packages/react/src/bottom-sheet/BottomSheet.ts
@@ -16,7 +16,13 @@ export type { M3eBottomSheetElement } from "@m3e/web/bottom-sheet";
  * See the `m3e-bottom-sheet` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eBottomSheet = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eBottomSheet = isBrowser ? createComponent({
   tagName: "m3e-bottom-sheet",
   elementClass: M3eBottomSheetElement,
   react: React,
@@ -27,4 +33,4 @@ export const M3eBottomSheet = createComponent({
     onClosed: "closed",
     onCancel: "cancel",
   },
-});
+}) : null;

--- a/packages/react/src/bottom-sheet/BottomSheetAction.ts
+++ b/packages/react/src/bottom-sheet/BottomSheetAction.ts
@@ -17,8 +17,14 @@ export type { M3eBottomSheetActionElement } from "@m3e/web/bottom-sheet";
  * See the `m3e-bottom-sheet-action` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eBottomSheetAction = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eBottomSheetAction = isBrowser ? createComponent({
   tagName: "m3e-bottom-sheet-action",
   elementClass: M3eBottomSheetActionElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/bottom-sheet/BottomSheetTrigger.ts
+++ b/packages/react/src/bottom-sheet/BottomSheetTrigger.ts
@@ -17,8 +17,14 @@ export type { M3eBottomSheetTriggerElement } from "@m3e/web/bottom-sheet";
  * See the `m3e-bottom-sheet-trigger` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eBottomSheetTrigger = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eBottomSheetTrigger = isBrowser ? createComponent({
   tagName: "m3e-bottom-sheet-trigger",
   elementClass: M3eBottomSheetTriggerElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/button-group/ButtonGroup.ts
+++ b/packages/react/src/button-group/ButtonGroup.ts
@@ -17,8 +17,14 @@ export type { ButtonGroupSize, ButtonGroupVariant, M3eButtonGroupElement } from 
  * See the `m3e-button-group` documentation in `@m3e/button-group` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eButtonGroup = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eButtonGroup = isBrowser ? createComponent({
   tagName: "m3e-button-group",
   elementClass: M3eButtonGroupElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/button/Button.ts
+++ b/packages/react/src/button/Button.ts
@@ -17,7 +17,13 @@ export type { ButtonShape, ButtonSize, ButtonVariant, M3eButtonElement } from "@
  * See the `m3e-button` documentation in `@m3e/button` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eButton = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eButton = isBrowser ? createComponent({
   tagName: "m3e-button",
   elementClass: M3eButtonElement,
   react: React,

--- a/packages/react/src/card/Card.ts
+++ b/packages/react/src/card/Card.ts
@@ -17,11 +17,17 @@ export type { CardOrientation, CardVariant, M3eCardElement } from "@m3e/web/card
  * See the `m3e-card` documentation in `@m3e/card` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eCard = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eCard = isBrowser ? createComponent({
   tagName: "m3e-card",
   elementClass: M3eCardElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/checkbox/Checkbox.ts
+++ b/packages/react/src/checkbox/Checkbox.ts
@@ -17,7 +17,13 @@ export type { M3eCheckboxElement } from "@m3e/web/checkbox";
  * See the `m3e-checkbox` documentation in `@m3e/checkbox` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eCheckbox = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eCheckbox = isBrowser ? createComponent({
   tagName: "m3e-checkbox",
   elementClass: M3eCheckboxElement,
   react: React,
@@ -27,4 +33,4 @@ export const M3eCheckbox = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/chips/AssistChip.ts
+++ b/packages/react/src/chips/AssistChip.ts
@@ -17,11 +17,17 @@ export type { M3eAssistChipElement } from "@m3e/web/chips";
  * See the `m3e-assist-chip` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eAssistChip = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eAssistChip = isBrowser ? createComponent({
   tagName: "m3e-assist-chip",
   elementClass: M3eAssistChipElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/chips/Chip.ts
+++ b/packages/react/src/chips/Chip.ts
@@ -17,8 +17,14 @@ export type { ChipVariant, M3eChipElement } from "@m3e/web/chips";
  * See the `m3e-chip` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eChip = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eChip = isBrowser ? createComponent({
   tagName: "m3e-chip",
   elementClass: M3eChipElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/chips/ChipSet.ts
+++ b/packages/react/src/chips/ChipSet.ts
@@ -17,8 +17,14 @@ export type { M3eChipSetElement } from "@m3e/web/chips";
  * See the `m3e-chip-set` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eChipSet = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eChipSet = isBrowser ? createComponent({
   tagName: "m3e-chip-set",
   elementClass: M3eChipSetElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/chips/FilterChip.ts
+++ b/packages/react/src/chips/FilterChip.ts
@@ -17,7 +17,13 @@ export type { M3eFilterChipElement } from "@m3e/web/chips";
  * See the `m3e-filter-chip` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eFilterChip = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eFilterChip = isBrowser ? createComponent({
   tagName: "m3e-filter-chip",
   elementClass: M3eFilterChipElement,
   react: React,

--- a/packages/react/src/chips/FilterChipSet.ts
+++ b/packages/react/src/chips/FilterChipSet.ts
@@ -17,7 +17,13 @@ export type { M3eFilterChipSetElement } from "@m3e/web/chips";
  * See the `m3e-filter-chip-set` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eFilterChipSet = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eFilterChipSet = isBrowser ? createComponent({
   tagName: "m3e-filter-chip-set",
   elementClass: M3eFilterChipSetElement,
   react: React,
@@ -25,4 +31,4 @@ export const M3eFilterChipSet = createComponent({
     onInput: "input",
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/chips/InputChip.ts
+++ b/packages/react/src/chips/InputChip.ts
@@ -17,7 +17,13 @@ export type { M3eInputChipElement } from "@m3e/web/chips";
  * See the `m3e-input-chip` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eInputChip = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eInputChip = isBrowser ? createComponent({
   tagName: "m3e-input-chip",
   elementClass: M3eInputChipElement,
   react: React,
@@ -25,4 +31,4 @@ export const M3eInputChip = createComponent({
     onClick: "click",
     onRemove: "remove",
   },
-});
+}) : null;

--- a/packages/react/src/chips/InputChipSet.ts
+++ b/packages/react/src/chips/InputChipSet.ts
@@ -17,11 +17,17 @@ export type { M3eInputChipSetElement } from "@m3e/web/chips";
  * See the `m3e-input-chip-set` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eInputChipSet = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eInputChipSet = isBrowser ? createComponent({
   tagName: "m3e-input-chip-set",
   elementClass: M3eInputChipSetElement,
   react: React,
   events: {
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/chips/SuggestionChip.ts
+++ b/packages/react/src/chips/SuggestionChip.ts
@@ -17,11 +17,17 @@ export type { M3eSuggestionChipElement } from "@m3e/web/chips";
  * See the `m3e-suggestion-chip` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSuggestionChip = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eSuggestionChip = isBrowser ? createComponent({
   tagName: "m3e-suggestion-chip",
   elementClass: M3eSuggestionChipElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/core/Collapsible.ts
+++ b/packages/react/src/core/Collapsible.ts
@@ -17,7 +17,13 @@ export type { M3eCollapsibleElement } from "@m3e/web/core";
  * See the `m3e-collapsible` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eCollapsible = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eCollapsible = isBrowser ? createComponent({
   tagName: "m3e-collapsible",
   elementClass: M3eCollapsibleElement,
   react: React,
@@ -27,4 +33,4 @@ export const M3eCollapsible = createComponent({
     onClosing: "closing",
     onClosed: "closed",
   },
-});
+}) : null;

--- a/packages/react/src/core/Elevation.ts
+++ b/packages/react/src/core/Elevation.ts
@@ -17,8 +17,14 @@ export type { M3eElevationElement, ElevationLevel } from "@m3e/web/core";
  * See the `m3e-elevation` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eElevation = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eElevation = isBrowser ? createComponent({
   tagName: "m3e-elevation",
   elementClass: M3eElevationElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/FocusRing.ts
+++ b/packages/react/src/core/FocusRing.ts
@@ -17,8 +17,14 @@ export type { M3eFocusRingElement } from "@m3e/web/core";
  * See the `m3e-focus-ring` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eFocusRing = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eFocusRing = isBrowser ? createComponent({
   tagName: "m3e-focus-ring",
   elementClass: M3eFocusRingElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/PseudoCheckbox.ts
+++ b/packages/react/src/core/PseudoCheckbox.ts
@@ -17,8 +17,14 @@ export type { M3ePseudoCheckboxElement } from "@m3e/web/core";
  * See the `m3e-pseudo-checkbox` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3ePseudoCheckbox = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3ePseudoCheckbox = isBrowser ? createComponent({
   tagName: "m3e-pseudo-checkbox",
   elementClass: M3ePseudoCheckboxElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/PseudoRadio.ts
+++ b/packages/react/src/core/PseudoRadio.ts
@@ -17,8 +17,14 @@ export type { M3ePseudoRadioElement } from "@m3e/web/core";
  * See the `m3e-pseudo-radio` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3ePseudoRadio = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3ePseudoRadio = isBrowser ? createComponent({
   tagName: "m3e-pseudo-radio",
   elementClass: M3ePseudoRadioElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/Ripple.ts
+++ b/packages/react/src/core/Ripple.ts
@@ -17,8 +17,14 @@ export type { M3eRippleElement } from "@m3e/web/core";
  * See the `m3e-ripple` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eRipple = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eRipple = isBrowser ? createComponent({
   tagName: "m3e-ripple",
   elementClass: M3eRippleElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/ScrollContainer.ts
+++ b/packages/react/src/core/ScrollContainer.ts
@@ -17,8 +17,14 @@ export type { M3eScrollContainerElement, ScrollDividers } from "@m3e/web/core";
  * See the `m3e-scroll-container` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eScrollContainer = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eScrollContainer = isBrowser ? createComponent({
   tagName: "m3e-scroll-container",
   elementClass: M3eScrollContainerElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/Slide.ts
+++ b/packages/react/src/core/Slide.ts
@@ -17,8 +17,14 @@ export type { M3eSlideElement } from "@m3e/web/core";
  * See the `m3e-slide` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSlide = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eSlide = isBrowser ? createComponent({
   tagName: "m3e-slide",
   elementClass: M3eSlideElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/StateLayer.ts
+++ b/packages/react/src/core/StateLayer.ts
@@ -17,8 +17,14 @@ export type { M3eStateLayerElement } from "@m3e/web/core";
  * See the `m3e-state-layer` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eStateLayer = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eStateLayer = isBrowser ? createComponent({
   tagName: "m3e-state-layer",
   elementClass: M3eStateLayerElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/TextHighlight.ts
+++ b/packages/react/src/core/TextHighlight.ts
@@ -17,8 +17,14 @@ export type { M3eTextHighlightElement } from "@m3e/web/core";
  * See the `m3e-text-highlight` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eTextHighlight = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eTextHighlight = isBrowser ? createComponent({
   tagName: "m3e-text-highlight",
   elementClass: M3eTextHighlightElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/core/TextOverflow.ts
+++ b/packages/react/src/core/TextOverflow.ts
@@ -17,8 +17,14 @@ export type { M3eTextOverflowElement } from "@m3e/web/core";
  * See the `m3e-text-overflow` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eTextOverflow = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eTextOverflow = isBrowser ? createComponent({
   tagName: "m3e-text-overflow",
   elementClass: M3eTextOverflowElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/dialog/Dialog.ts
+++ b/packages/react/src/dialog/Dialog.ts
@@ -17,7 +17,13 @@ export type { M3eDialogElement } from "@m3e/web/dialog";
  * See the `m3e-dialog` documentation in `@m3e/dialog` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eDialog = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eDialog = isBrowser ? createComponent({
   tagName: "m3e-dialog",
   elementClass: M3eDialogElement,
   react: React,
@@ -28,4 +34,4 @@ export const M3eDialog = createComponent({
     onClosed: "closed",
     onCancel: "cancel",
   },
-});
+}) : null;

--- a/packages/react/src/dialog/DialogAction.ts
+++ b/packages/react/src/dialog/DialogAction.ts
@@ -17,8 +17,14 @@ export type { M3eDialogActionElement } from "@m3e/web/dialog";
  * See the `m3e-dialog-action` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eDialogAction = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eDialogAction = isBrowser ? createComponent({
   tagName: "m3e-dialog-action",
   elementClass: M3eDialogActionElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/dialog/DialogTrigger.ts
+++ b/packages/react/src/dialog/DialogTrigger.ts
@@ -17,8 +17,14 @@ export type { M3eDialogTriggerElement } from "@m3e/web/dialog";
  * See the `m3e-dialog-trigger` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eDialogTrigger = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eDialogTrigger = isBrowser ? createComponent({
   tagName: "m3e-dialog-trigger",
   elementClass: M3eDialogTriggerElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/divider/Divider.ts
+++ b/packages/react/src/divider/Divider.ts
@@ -17,8 +17,14 @@ export type { M3eDividerElement } from "@m3e/web/divider";
  * See the `m3e-divider` documentation in `@m3e/divider` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eDivider = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eDivider = isBrowser ? createComponent({
   tagName: "m3e-divider",
   elementClass: M3eDividerElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/drawer-container/DrawerContainer.ts
+++ b/packages/react/src/drawer-container/DrawerContainer.ts
@@ -17,11 +17,17 @@ export type { DrawerMode, DrawerPosition, M3eDrawerContainerElement } from "@m3e
  * See the `m3e-drawer-container` documentation in `@m3e/drawer-container` for full details on behavior,
  * styling, accessibility, and supported events.
  */
-export const M3eDrawerContainer = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eDrawerContainer = isBrowser ? createComponent({
   tagName: "m3e-drawer-container",
   elementClass: M3eDrawerContainerElement,
   react: React,
   events: {
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/drawer-container/DrawerToggle.ts
+++ b/packages/react/src/drawer-container/DrawerToggle.ts
@@ -17,8 +17,13 @@ export type { M3eDrawerToggleElement } from "@m3e/web/drawer-container";
  * See the `m3e-drawer-toggle` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eDrawerToggle = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eDrawerToggle = isBrowser ? createComponent({
   tagName: "m3e-drawer-toggle",
   elementClass: M3eDrawerToggleElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/expansion-panel/Accordion.ts
+++ b/packages/react/src/expansion-panel/Accordion.ts
@@ -17,8 +17,14 @@ export type { M3eAccordionElement } from "@m3e/web/expansion-panel";
  * See the `m3e-accordion` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eAccordion = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eAccordion = isBrowser ? createComponent({
   tagName: "m3e-accordion",
   elementClass: M3eAccordionElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/expansion-panel/ExpansionPanel.ts
+++ b/packages/react/src/expansion-panel/ExpansionPanel.ts
@@ -21,7 +21,13 @@ export type {
  * See the `m3e-expansion-panel` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eExpansionPanel = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+
+export const M3eExpansionPanel = isBrowser ? createComponent({
   tagName: "m3e-expansion-panel",
   elementClass: M3eExpansionPanelElement,
   react: React,
@@ -31,4 +37,4 @@ export const M3eExpansionPanel = createComponent({
     onClosing: "closing",
     onClosed: "closed",
   },
-});
+}) : null;

--- a/packages/react/src/fab-menu/FabMenu.ts
+++ b/packages/react/src/fab-menu/FabMenu.ts
@@ -17,7 +17,12 @@ export type { FabMenuVariant, M3eFabMenuElement } from "@m3e/web/fab-menu";
  * See the `m3e-fab-menu` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eFabMenu = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eFabMenu = isBrowser ? createComponent({
   tagName: "m3e-fab-menu",
   elementClass: M3eFabMenuElement,
   react: React,
@@ -25,4 +30,4 @@ export const M3eFabMenu = createComponent({
     onBeforeToggle: "beforetoggle",
     onToggle: "toggle",
   },
-});
+}) : null;

--- a/packages/react/src/fab-menu/FabMenuItem.ts
+++ b/packages/react/src/fab-menu/FabMenuItem.ts
@@ -17,11 +17,16 @@ export type { M3eFabMenuItemElement } from "@m3e/web/fab-menu";
  * See the `m3e-fab-menu-item` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eFabMenuItem = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eFabMenuItem = isBrowser ? createComponent({
   tagName: "m3e-fab-menu-item",
   elementClass: M3eFabMenuItemElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/fab-menu/FabMenuTrigger.ts
+++ b/packages/react/src/fab-menu/FabMenuTrigger.ts
@@ -17,8 +17,13 @@ export type { M3eFabMenuTriggerElement } from "@m3e/web/fab-menu";
  * See the `m3e-fab-menu-trigger` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eFabMenuTrigger = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eFabMenuTrigger = isBrowser ? createComponent({
   tagName: "m3e-fab-menu-trigger",
   elementClass: M3eFabMenuTriggerElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/fab/Fab.ts
+++ b/packages/react/src/fab/Fab.ts
@@ -17,11 +17,16 @@ export type { FabSize, FabVariant, M3eFabElement } from "@m3e/web/fab";
  * See the `m3e-fab` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eFab = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eFab = isBrowser ? createComponent({
   tagName: "m3e-fab",
   elementClass: M3eFabElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/form-field/FormField.ts
+++ b/packages/react/src/form-field/FormField.ts
@@ -17,8 +17,13 @@ export type { FloatLabelType, FormFieldVariant, FormFieldControl, M3eFormFieldEl
  * See the `m3e-form-field` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eFormField = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eFormField = isBrowser ? createComponent({
   tagName: "m3e-form-field",
   elementClass: M3eFormFieldElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/heading/Heading.ts
+++ b/packages/react/src/heading/Heading.ts
@@ -17,8 +17,13 @@ export type { HeadingLevel, HeadingSize, HeadingVariant, M3eHeadingElement } fro
  * See the `m3e-heading` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eHeading = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eHeading = isBrowser ? createComponent({
   tagName: "m3e-heading",
   elementClass: M3eHeadingElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/icon-button/IconButton.ts
+++ b/packages/react/src/icon-button/IconButton.ts
@@ -23,7 +23,12 @@ export type {
  * See the `m3e-icon-button` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eIconButton = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eIconButton = isBrowser ? createComponent({
   tagName: "m3e-icon-button",
   elementClass: M3eIconButtonElement,
   react: React,
@@ -32,4 +37,4 @@ export const M3eIconButton = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/icon/Icon.ts
+++ b/packages/react/src/icon/Icon.ts
@@ -17,8 +17,13 @@ export type { IconGrade, IconVariant, M3eIconElement } from "@m3e/web/icon";
  * See the `m3e-icon` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eIcon = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eIcon = isBrowser ? createComponent({
   tagName: "m3e-icon",
   elementClass: M3eIconElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/list/ActionList.ts
+++ b/packages/react/src/list/ActionList.ts
@@ -17,8 +17,13 @@ export type { M3eActionListElement } from "@m3e/web/list";
  * See the `m3e-action-list` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eActionList = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eActionList = isBrowser ? createComponent({
   tagName: "m3e-action-list",
   elementClass: M3eActionListElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/list/ExpandableListItem.ts
+++ b/packages/react/src/list/ExpandableListItem.ts
@@ -17,7 +17,12 @@ export type { M3eExpandableListItemElement } from "@m3e/web/list";
  * See the `m3e-expandable-list-item` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eExpandableListItem = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eExpandableListItem = isBrowser ? createComponent({
   tagName: "m3e-expandable-list-item",
   elementClass: M3eExpandableListItemElement,
   react: React,
@@ -27,4 +32,4 @@ export const M3eExpandableListItem = createComponent({
     onClosing: "closing",
     onClosed: "closed",
   },
-});
+}) : null;

--- a/packages/react/src/list/List.ts
+++ b/packages/react/src/list/List.ts
@@ -17,8 +17,13 @@ export type { ListVariant, M3eListElement } from "@m3e/web/list";
  * See the `m3e-list` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eList = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eList = isBrowser ? createComponent({
   tagName: "m3e-list",
   elementClass: M3eListElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/list/ListAction.ts
+++ b/packages/react/src/list/ListAction.ts
@@ -17,11 +17,16 @@ export type { M3eListActionElement } from "@m3e/web/list";
  * See the `m3e-list-action` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eListAction = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eListAction = isBrowser ? createComponent({
   tagName: "m3e-list-action",
   elementClass: M3eListActionElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/list/ListItem.ts
+++ b/packages/react/src/list/ListItem.ts
@@ -17,8 +17,13 @@ export type { M3eListItemElement } from "@m3e/web/list";
  * See the `m3e-list-item` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eListItem = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eListItem = isBrowser ? createComponent({
   tagName: "m3e-list-item",
   elementClass: M3eListItemElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/list/ListOption.ts
+++ b/packages/react/src/list/ListOption.ts
@@ -17,7 +17,12 @@ export type { M3eListOptionElement } from "@m3e/web/list";
  * See the `m3e-list-option` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eListOption = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eListOption = isBrowser ? createComponent({
   tagName: "m3e-list-option",
   elementClass: M3eListOptionElement,
   react: React,
@@ -26,4 +31,4 @@ export const M3eListOption = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/list/SelectionList.ts
+++ b/packages/react/src/list/SelectionList.ts
@@ -17,7 +17,12 @@ export type { M3eSelectionListElement } from "@m3e/web/list";
  * See the `m3e-selection-list` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSelectionList = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSelectionList = isBrowser ? createComponent({
   tagName: "m3e-selection-list",
   elementClass: M3eSelectionListElement,
   react: React,
@@ -25,4 +30,4 @@ export const M3eSelectionList = createComponent({
     onInput: "input",
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/loading-indicator/LoadingIndicator.ts
+++ b/packages/react/src/loading-indicator/LoadingIndicator.ts
@@ -17,8 +17,13 @@ export type { LoadingIndicatorVariant, M3eLoadingIndicatorElement } from "@m3e/w
  * See the `m3e-loading-indicator` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eLoadingIndicator = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eLoadingIndicator = isBrowser ? createComponent({
   tagName: "m3e-loading-indicator",
   elementClass: M3eLoadingIndicatorElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/menu/Menu.ts
+++ b/packages/react/src/menu/Menu.ts
@@ -17,7 +17,12 @@ export type { MenuPositionX, MenuPositionY, MenuVariant, M3eMenuElement } from "
  * See the `m3e-menu` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eMenu = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eMenu = isBrowser ? createComponent({
   tagName: "m3e-menu",
   elementClass: M3eMenuElement,
   react: React,
@@ -25,4 +30,4 @@ export const M3eMenu = createComponent({
     onBeforeToggle: "beforetoggle",
     onToggle: "toggle",
   },
-});
+}) : null;

--- a/packages/react/src/menu/MenuItem.ts
+++ b/packages/react/src/menu/MenuItem.ts
@@ -17,11 +17,16 @@ export type { M3eMenuItemElement } from "@m3e/web/menu";
  * See the `m3e-menu-item` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eMenuItem = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eMenuItem = isBrowser ? createComponent({
   tagName: "m3e-menu-item",
   elementClass: M3eMenuItemElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/menu/MenuItemCheckbox.ts
+++ b/packages/react/src/menu/MenuItemCheckbox.ts
@@ -17,11 +17,16 @@ export type { M3eMenuItemCheckboxElement } from "@m3e/web/menu";
  * See the `m3e-menu-item-checkbox` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eMenuItemCheckbox = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eMenuItemCheckbox = isBrowser ? createComponent({
   tagName: "m3e-menu-item-checkbox",
   elementClass: M3eMenuItemCheckboxElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/menu/MenuItemGroup.ts
+++ b/packages/react/src/menu/MenuItemGroup.ts
@@ -17,8 +17,13 @@ export type { M3eMenuItemGroupElement } from "@m3e/web/menu";
  * See the `m3e-menu-item-group` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eMenuItemGroup = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eMenuItemGroup = isBrowser ? createComponent({
   tagName: "m3e-menu-item-group",
   elementClass: M3eMenuItemGroupElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/menu/MenuItemRadio.ts
+++ b/packages/react/src/menu/MenuItemRadio.ts
@@ -17,11 +17,16 @@ export type { M3eMenuItemRadioElement } from "@m3e/web/menu";
  * See the `m3e-menu-item-radio` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eMenuItemRadio = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eMenuItemRadio = isBrowser ? createComponent({
   tagName: "m3e-menu-item-radio",
   elementClass: M3eMenuItemRadioElement,
   react: React,
   events: {
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/menu/MenuTrigger.ts
+++ b/packages/react/src/menu/MenuTrigger.ts
@@ -17,8 +17,13 @@ export type { M3eMenuTriggerElement } from "@m3e/web/menu";
  * See the `m3e-menu-trigger` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eMenuTrigger = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eMenuTrigger = isBrowser ? createComponent({
   tagName: "m3e-menu-trigger",
   elementClass: M3eMenuTriggerElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/nav-bar/NavBar.ts
+++ b/packages/react/src/nav-bar/NavBar.ts
@@ -17,11 +17,16 @@ export type { NavBarMode, NavItemOrientation, M3eNavBarElement } from "@m3e/web/
  * See the `m3e-nav-bar` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eNavBar = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eNavBar = isBrowser ? createComponent({
   tagName: "m3e-nav-bar",
   elementClass: M3eNavBarElement,
   react: React,
   events: {
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/nav-bar/NavItem.ts
+++ b/packages/react/src/nav-bar/NavItem.ts
@@ -17,7 +17,12 @@ export type { M3eNavItemElement } from "@m3e/web/nav-bar";
  * See the `m3e-nav-item` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eNavItem = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eNavItem = isBrowser ? createComponent({
   tagName: "m3e-nav-item",
   elementClass: M3eNavItemElement,
   react: React,
@@ -26,4 +31,4 @@ export const M3eNavItem = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/nav-menu/NavMenu.ts
+++ b/packages/react/src/nav-menu/NavMenu.ts
@@ -17,8 +17,13 @@ export type { M3eNavMenuElement } from "@m3e/web/nav-menu";
  * See the `m3e-nav-menu` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eNavMenu = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eNavMenu = isBrowser ? createComponent({
   tagName: "m3e-nav-menu",
   elementClass: M3eNavMenuElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/nav-menu/NavMenuItem.ts
+++ b/packages/react/src/nav-menu/NavMenuItem.ts
@@ -17,7 +17,12 @@ export type { M3eNavMenuItemElement } from "@m3e/web/nav-menu";
  * See the `m3e-nav-menu-item` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eNavMenuItem = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eNavMenuItem = isBrowser ? createComponent({
   tagName: "m3e-nav-menu-item",
   elementClass: M3eNavMenuItemElement,
   react: React,
@@ -28,4 +33,4 @@ export const M3eNavMenuItem = createComponent({
     onClosed: "closed",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/nav-menu/NavMenuItemGroup.ts
+++ b/packages/react/src/nav-menu/NavMenuItemGroup.ts
@@ -17,8 +17,13 @@ export type { M3eNavMenuItemGroupElement } from "@m3e/web/nav-menu";
  * See the `m3e-nav-menu-item-group` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eNavMenuItemGroup = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eNavMenuItemGroup = isBrowser ? createComponent({
   tagName: "m3e-nav-menu-item-group",
   elementClass: M3eNavMenuItemGroupElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/nav-rail/NavRail.ts
+++ b/packages/react/src/nav-rail/NavRail.ts
@@ -17,11 +17,16 @@ export type { M3eNavRailElement } from "@m3e/web/nav-rail";
  * See the `m3e-nav-rail` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eNavRail = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eNavRail = isBrowser ? createComponent({
   tagName: "m3e-nav-rail",
   elementClass: M3eNavRailElement,
   react: React,
   events: {
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/nav-rail/NavRailToggle.ts
+++ b/packages/react/src/nav-rail/NavRailToggle.ts
@@ -17,8 +17,13 @@ export type { M3eNavRailToggleElement } from "@m3e/web/nav-rail";
  * See the `m3e-nav-rail-toggle` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eNavRailToggle = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eNavRailToggle = isBrowser ? createComponent({
   tagName: "m3e-nav-rail-toggle",
   elementClass: M3eNavRailToggleElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/option/OptGroup.ts
+++ b/packages/react/src/option/OptGroup.ts
@@ -17,8 +17,13 @@ export type { M3eOptGroupElement } from "@m3e/web/option";
  * See the `m3e-optgroup` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eOptGroup = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eOptGroup = isBrowser ? createComponent({
   tagName: "m3e-optgroup",
   elementClass: M3eOptGroupElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/option/Option.ts
+++ b/packages/react/src/option/Option.ts
@@ -17,8 +17,13 @@ export type { M3eOptionElement } from "@m3e/web/option";
  * See the `m3e-option` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eOption = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eOption = isBrowser ? createComponent({
   tagName: "m3e-option",
   elementClass: M3eOptionElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/paginator/Paginator.ts
+++ b/packages/react/src/paginator/Paginator.ts
@@ -17,11 +17,16 @@ export type { M3ePaginatorElement, PageEventDetail } from "@m3e/web/paginator";
  * See the `m3e-paginator` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3ePaginator = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3ePaginator = isBrowser ? createComponent({
   tagName: "m3e-paginator",
   elementClass: M3ePaginatorElement,
   react: React,
   events: {
     onPage: "page" as EventName<CustomEvent<PageEventDetail>>,
   },
-});
+}) : null;

--- a/packages/react/src/progress-indicator/CircularProgressIndicator.ts
+++ b/packages/react/src/progress-indicator/CircularProgressIndicator.ts
@@ -17,8 +17,13 @@ export type { M3eCircularProgressIndicatorElement } from "@m3e/web/progress-indi
  * See the `m3e-circular-progress-indicator` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eCircularProgressIndicator = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eCircularProgressIndicator = isBrowser ? createComponent({
   tagName: "m3e-circular-progress-indicator",
   elementClass: M3eCircularProgressIndicatorElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/progress-indicator/LinearProgressIndicator.ts
+++ b/packages/react/src/progress-indicator/LinearProgressIndicator.ts
@@ -21,8 +21,13 @@ export type {
  * See the `m3e-linear-progress-indicator` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eLinearProgressIndicator = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eLinearProgressIndicator = isBrowser ? createComponent({
   tagName: "m3e-linear-progress-indicator",
   elementClass: M3eLinearProgressIndicatorElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/radio-group/Radio.ts
+++ b/packages/react/src/radio-group/Radio.ts
@@ -17,7 +17,12 @@ export type { M3eRadioElement } from "@m3e/web/radio-group";
  * See the `m3e-radio` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eRadio = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eRadio = isBrowser ? createComponent({
   tagName: "m3e-radio",
   elementClass: M3eRadioElement,
   react: React,
@@ -26,4 +31,4 @@ export const M3eRadio = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/radio-group/RadioGroup.ts
+++ b/packages/react/src/radio-group/RadioGroup.ts
@@ -17,11 +17,16 @@ export type { M3eRadioGroupElement } from "@m3e/web/radio-group";
  * See the `m3e-radio-group` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eRadioGroup = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eRadioGroup = isBrowser ? createComponent({
   tagName: "m3e-radio-group",
   elementClass: M3eRadioGroupElement,
   react: React,
   events: {
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/segmented-button/ButtonSegment.ts
+++ b/packages/react/src/segmented-button/ButtonSegment.ts
@@ -17,7 +17,12 @@ export type { M3eButtonSegmentElement } from "@m3e/web/segmented-button";
  * See the `m3e-button-segment` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eButtonSegment = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eButtonSegment = isBrowser ? createComponent({
   tagName: "m3e-button-segment",
   elementClass: M3eButtonSegmentElement,
   react: React,
@@ -26,4 +31,4 @@ export const M3eButtonSegment = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/segmented-button/SegmentedButton.ts
+++ b/packages/react/src/segmented-button/SegmentedButton.ts
@@ -17,7 +17,12 @@ export type { M3eSegmentedButtonElement } from "@m3e/web/segmented-button";
  * See the `m3e-segmented-button` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSegmentedButton = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSegmentedButton = isBrowser ? createComponent({
   tagName: "m3e-segmented-button",
   elementClass: M3eSegmentedButtonElement,
   react: React,
@@ -25,4 +30,4 @@ export const M3eSegmentedButton = createComponent({
     onInput: "input",
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/select/Select.ts
+++ b/packages/react/src/select/Select.ts
@@ -17,7 +17,12 @@ export type { M3eSelectElement } from "@m3e/web/select";
  * See the `m3e-select` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSelect = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSelect = isBrowser ? createComponent({
   tagName: "m3e-select",
   elementClass: M3eSelectElement,
   react: React,

--- a/packages/react/src/shape/Shape.ts
+++ b/packages/react/src/shape/Shape.ts
@@ -17,7 +17,12 @@ export type { M3eShapeElement, ShapeName } from "@m3e/web/shape";
  * See the `m3e-shape` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eShape = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eShape = isBrowser ? createComponent({
   tagName: "m3e-shape",
   elementClass: M3eShapeElement,
   react: React,

--- a/packages/react/src/slide-group/SlideGroup.ts
+++ b/packages/react/src/slide-group/SlideGroup.ts
@@ -17,8 +17,13 @@ export type { M3eSlideGroupElement } from "@m3e/web/slide-group";
  * See the `m3e-slide-group` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSlideGroup = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSlideGroup = isBrowser ? createComponent({
   tagName: "m3e-slide-group",
   elementClass: M3eSlideGroupElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/slider/Slider.ts
+++ b/packages/react/src/slider/Slider.ts
@@ -17,8 +17,13 @@ export type { M3eSliderElement, SliderSize } from "@m3e/web/slider";
  * See the `m3e-slider` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSlider = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSlider = isBrowser ? createComponent({
   tagName: "m3e-slider",
   elementClass: M3eSliderElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/slider/SliderThumb.ts
+++ b/packages/react/src/slider/SliderThumb.ts
@@ -17,7 +17,12 @@ export type { M3eSliderThumbElement } from "@m3e/web/slider";
  * See the `m3e-slider-thumb` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSliderThumb = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSliderThumb = isBrowser ? createComponent({
   tagName: "m3e-slider-thumb",
   elementClass: M3eSliderThumbElement,
   react: React,
@@ -26,4 +31,4 @@ export const M3eSliderThumb = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/snackbar/Snackbar.ts
+++ b/packages/react/src/snackbar/Snackbar.ts
@@ -1,2 +1,29 @@
-export { M3eSnackbar } from "@m3e/web/snackbar";
+import React from "react";
+import { createComponent } from "@lit/react";
+
+import { M3eSnackbarElement } from "@m3e/web/snackbar";
 export type { M3eSnackbarElement, SnackbarOptions } from "@m3e/web/snackbar";
+
+/**
+ * React binding for the `m3e-snackbar` Web Component from `@m3e/web/snackbar`.
+ *
+ * This component renders the underlying `<m3e-snackbar>` element and exposes its
+ * properties, attributes, and events through an idiomatic React interface.
+ *
+ * Props map directly to element properties, and event handlers receive the
+ * native DOM events dispatched by the component. Refs are forwarded to the
+ * underlying `<m3e-snackbar>` instance for imperative access.
+ *
+ * See the `m3e-snackbar` documentation for full details on behavior, styling,
+ * accessibility, and supported events.
+ */
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSnackbar = isBrowser ? createComponent({
+  tagName: "m3e-snackbar",
+  elementClass: M3eSnackbarElement,
+  react: React,
+}) : null;

--- a/packages/react/src/split-button/SplitButton.ts
+++ b/packages/react/src/split-button/SplitButton.ts
@@ -17,8 +17,13 @@ export type { M3eSplitButtonElement, SplitButtonVariant } from "@m3e/web/split-b
  * See the `m3e-split-button` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSplitButton = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSplitButton = isBrowser ? createComponent({
   tagName: "m3e-split-button",
   elementClass: M3eSplitButtonElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/stepper/Step.ts
+++ b/packages/react/src/stepper/Step.ts
@@ -17,7 +17,12 @@ export type { M3eStepElement } from "@m3e/web/stepper";
  * See the `m3e-step` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eStep = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eStep = isBrowser ? createComponent({
   tagName: "m3e-step",
   elementClass: M3eStepElement,
   react: React,
@@ -26,4 +31,4 @@ export const M3eStep = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/stepper/StepPanel.ts
+++ b/packages/react/src/stepper/StepPanel.ts
@@ -17,8 +17,13 @@ export type { M3eStepPanelElement } from "@m3e/web/stepper";
  * See the `m3e-step-panel` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eStepPanel = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eStepPanel = isBrowser ? createComponent({
   tagName: "m3e-step-panel",
   elementClass: M3eStepPanelElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/stepper/Stepper.ts
+++ b/packages/react/src/stepper/Stepper.ts
@@ -17,11 +17,16 @@ export type { M3eStepperElement, StepperOrientation, StepLabelPosition, StepHead
  * See the `m3e-stepper` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eStepper = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eStepper = isBrowser ? createComponent({
   tagName: "m3e-stepper",
   elementClass: M3eStepperElement,
   react: React,
   events: {
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/stepper/StepperNext.ts
+++ b/packages/react/src/stepper/StepperNext.ts
@@ -17,8 +17,13 @@ export type { M3eStepperNextElement } from "@m3e/web/stepper";
  * See the `m3e-stepper-next` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eStepperNext = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eStepperNext = isBrowser ? createComponent({
   tagName: "m3e-stepper-next",
   elementClass: M3eStepperNextElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/stepper/StepperPrevious.ts
+++ b/packages/react/src/stepper/StepperPrevious.ts
@@ -17,8 +17,13 @@ export type { M3eStepperPreviousElement } from "@m3e/web/stepper";
  * See the `m3e-stepper-previous` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eStepperPrevious = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eStepperPrevious = isBrowser ? createComponent({
   tagName: "m3e-stepper-previous",
   elementClass: M3eStepperPreviousElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/stepper/StepperReset.ts
+++ b/packages/react/src/stepper/StepperReset.ts
@@ -17,8 +17,13 @@ export type { M3eStepperResetElement } from "@m3e/web/stepper";
  * See the `m3e-stepper-reset` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eStepperReset = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eStepperReset = isBrowser ? createComponent({
   tagName: "m3e-stepper-reset",
   elementClass: M3eStepperResetElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/switch/Switch.ts
+++ b/packages/react/src/switch/Switch.ts
@@ -17,7 +17,12 @@ export type { M3eSwitchElement, SwitchIcons } from "@m3e/web/switch";
  * See the `m3e-switch` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eSwitch = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eSwitch = isBrowser ? createComponent({
   tagName: "m3e-switch",
   elementClass: M3eSwitchElement,
   react: React,
@@ -26,4 +31,4 @@ export const M3eSwitch = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/tabs/Tab.ts
+++ b/packages/react/src/tabs/Tab.ts
@@ -17,7 +17,12 @@ export type { M3eTabElement } from "@m3e/web/tabs";
  * See the `m3e-tab` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eTab = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eTab = isBrowser ? createComponent({
   tagName: "m3e-tab",
   elementClass: M3eTabElement,
   react: React,
@@ -26,4 +31,4 @@ export const M3eTab = createComponent({
     onChange: "change",
     onClick: "click",
   },
-});
+}) : null;

--- a/packages/react/src/tabs/TabPanel.ts
+++ b/packages/react/src/tabs/TabPanel.ts
@@ -17,8 +17,13 @@ export type { M3eTabPanelElement } from "@m3e/web/tabs";
  * See the `m3e-tab-panel` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eTabPanel = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eTabPanel = isBrowser ? createComponent({
   tagName: "m3e-tab-panel",
   elementClass: M3eTabPanelElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/tabs/Tabs.ts
+++ b/packages/react/src/tabs/Tabs.ts
@@ -17,11 +17,16 @@ export type { M3eTabsElement, TabVariant, TabHeaderPosition } from "@m3e/web/tab
  * See the `m3e-tabs` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eTabs = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eTabs = isBrowser ? createComponent({
   tagName: "m3e-tabs",
   elementClass: M3eTabsElement,
   react: React,
   events: {
     onChange: "change",
   },
-});
+}) : null;

--- a/packages/react/src/textarea-autosize/TextareaAutosize.ts
+++ b/packages/react/src/textarea-autosize/TextareaAutosize.ts
@@ -17,8 +17,13 @@ export type { M3eTextareaAutosizeElement } from "@m3e/web/textarea-autosize";
  * See the `m3e-textarea-autosize` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eTextareaAutosize = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eTextareaAutosize = isBrowser ? createComponent({
   tagName: "m3e-textarea-autosize",
   elementClass: M3eTextareaAutosizeElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/theme/Theme.ts
+++ b/packages/react/src/theme/Theme.ts
@@ -17,7 +17,12 @@ export type { ColorScheme, ContrastLevel, MotionScheme, M3eThemeElement } from "
  * See the `m3e-theme` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eTheme = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eTheme = isBrowser ? createComponent({
   tagName: "m3e-theme",
   elementClass: M3eThemeElement,
   react: React,

--- a/packages/react/src/toc/Toc.ts
+++ b/packages/react/src/toc/Toc.ts
@@ -17,7 +17,12 @@ export type { M3eTocElement } from "@m3e/web/toc";
  * See the `m3e-toc` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eToc = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eToc = isBrowser ? createComponent({
   tagName: "m3e-toc",
   elementClass: M3eTocElement,
   react: React,

--- a/packages/react/src/toolbar/Toolbar.ts
+++ b/packages/react/src/toolbar/Toolbar.ts
@@ -17,8 +17,12 @@ export type { M3eToolbarElement, ToolbarVariant, ToolbarShape } from "@m3e/web/t
  * See the `m3e-toolbar` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eToolbar = createComponent({
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eToolbar = isBrowser ? createComponent({
   tagName: "m3e-toolbar",
   elementClass: M3eToolbarElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/tooltip/RichTooltip.ts
+++ b/packages/react/src/tooltip/RichTooltip.ts
@@ -17,7 +17,12 @@ export type { M3eRichTooltipElement, RichTooltipPosition } from "@m3e/web/toolti
  * See the `m3e-rich-tooltip` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eRichTooltip = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eRichTooltip = isBrowser ? createComponent({
   tagName: "m3e-rich-tooltip",
   elementClass: M3eRichTooltipElement,
   react: React,
@@ -25,4 +30,4 @@ export const M3eRichTooltip = createComponent({
     onBeforeToggle: "beforetoggle",
     onToggle: "toggle",
   },
-});
+}) : null;

--- a/packages/react/src/tooltip/RichTooltipAction.ts
+++ b/packages/react/src/tooltip/RichTooltipAction.ts
@@ -17,8 +17,13 @@ export type { M3eRichTooltipActionElement } from "@m3e/web/tooltip";
  * See the `m3e-rich-tooltip-action` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eRichTooltipAction = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eRichTooltipAction = isBrowser ? createComponent({
   tagName: "m3e-rich-tooltip-action",
   elementClass: M3eRichTooltipActionElement,
   react: React,
-});
+}) : null;

--- a/packages/react/src/tooltip/Tooltip.ts
+++ b/packages/react/src/tooltip/Tooltip.ts
@@ -17,8 +17,13 @@ export type { M3eTooltipElement, TooltipPosition, TooltipTouchGestures } from "@
  * See the `m3e-tooltip` documentation for full details on behavior, styling,
  * accessibility, and supported events.
  */
-export const M3eTooltip = createComponent({
+
+// Checking if the code is running in the browser
+const isBrowser = typeof window !== "undefined";
+
+// Defining element
+export const M3eTooltip = isBrowser ? createComponent({
   tagName: "m3e-tooltip",
   elementClass: M3eTooltipElement,
   react: React,
-});
+}) : null;


### PR DESCRIPTION
…ltejs, etc. adding m3esegment wrapper also.

Add a runtime check (isBrowser = typeof window !== "undefined") to React wrapper modules and only call createComponent when running in a browser. Each component export now returns the created component for browser environments or null for non-browser (SSR) environments to avoid window-related errors when importing on the server. Changes touch many wrappers under packages/react/src/* where the previous unconditional createComponent call was replaced with the guarded ternary expression.

---
name: Pull Request
about: Submit a pull request to propose changes to the Web Component library
---

## Description

Please describe your changes and the motivation behind them.

## Related Issue

If this PR addresses an open issue, please link to it here.

## Type of Change

- Bug fix -> I've added the condition ```typeof window !== "undefined" ``` to handle SSR and hydration error in Next JS to resolve issue #26.
- New feature -> Add a missing wrapper of component m3e-snackbar.

## Checklist

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [❌] I have added tests that prove my fix/feature works (if applicable)
- [not applicable.] I have added necessary documentation (if applicable)
- [✅] Any dependent changes have been merged and published

## Screenshots (if applicable)

<img width="657" height="569" alt="image" src="https://github.com/user-attachments/assets/fb3bab58-284a-46a8-a13f-bfbf65bcd6cd" />

## Additional Notes

Added:
<script>
// Checking if the code is running in the browser
const isBrowser = typeof window !== "undefined";

// Defining element

export const M3eButton = isBrowser ? createComponent({
  tagName: "m3e-button",
  elementClass: M3eButtonElement,
  react: React,
  events: {
    onInput: "input",
    onChange: "change",
    onClick: "click",
  },
});

</script>
