### PR TITLE
fix(rich-tooltip): ensure tooltip is connected before restoring focus

### DIFF
--- a/packages/web/src/tooltip/RichTooltipElement.ts
+++ b/packages/web/src/tooltip/RichTooltipElement.ts
@@ -278,9 +278,11 @@ export class M3eRichTooltipElement extends TooltipElementBase {
       document.removeEventListener("click", this.#documentClickHandler);
     }
 
+    const wasOpen = this.isOpen;
+
     super.hide();
 
-    if (restoreFocus && this.isConnected && this._interactive && this.control && M3eInteractivityChecker.isFocusable(this.control)) {
+    if (restoreFocus && wasOpen && this._interactive && this.control && M3eInteractivityChecker.isFocusable(this.control)) {
       this.control.focus();
     }
   }


### PR DESCRIPTION
This PR should fix this:
https://codepen.io/editor/ryansuhartanto/pen/019cc854-a47a-75a9-8862-46391fd7154f

Clicking randomize jumps the scroll randomly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published