### PR TITLE
Fix: typo in NavMenuItemElement.handleClick

### DIFF
--- a/packages/web/src/nav-menu/NavMenuItemElement.ts
+++ b/packages/web/src/nav-menu/NavMenuItemElement.ts
@@ -571,7 +571,7 @@ export class M3eNavMenuItemElement extends Selected(
 
       const drawerContainer = this.closest("m3e-drawer-container");
       if (drawerContainer) {
-        const drawer = this.closest("[slot='start']") ?? this.closest("[slot='end')");
+        const drawer = this.closest("[slot='start']") ?? this.closest("[slot='end']");
         if (
           drawer &&
           (hasCustomState(drawerContainer, `-${drawer.slot}-push`) ||


### PR DESCRIPTION
---
name: Simple typo in NavMenuItemElement.ts
about: Simple fix for a typo at line 572 in function handleClick()
---

## Description

Fix a browser console message when a Nav Menu Item is used

## Related Issue

If this PR addresses an open issue, please link to it here.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

<img width="1830" height="378" alt="image" src="https://github.com/user-attachments/assets/fe5b6481-820d-4789-b017-0014ec6db7e0" />

## Additional Notes

Add any other relevant information or context.
