### PR TITLE
fix(icon): use currentColor for SVG icons

### DIFF
--- a/packages/web/src/icon/IconElement.ts
+++ b/packages/web/src/icon/IconElement.ts
@@ -85,6 +85,7 @@ export class M3eIconElement extends Role(LitElement, "img") {
       font-family: "Material Symbols Sharp";
     }
     svg {
+      fill: currentColor;
       font-size: inherit;
       width: 1em;
       height: 1em;


### PR DESCRIPTION
## Description

Add `fill: currentColor` so SVG icons inherit the element's color. You can see this issue manifest on the demo site in dark mode:
https://matraic.github.io/m3e/components/icon.html#:~:text=as%20an%20alternative%20to%20use%20of%20variable%20fonts

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<img width="1102" height="91" alt="image" src="https://github.com/user-attachments/assets/7a87c2bf-7614-4502-9e5b-453cb8f20ad1" />
