### PR TITLE
fix(tooltip): use break-word to avoid aggressive shrinking

### DIFF
--- a/packages/web/src/tooltip/TooltipElement.ts
+++ b/packages/web/src/tooltip/TooltipElement.ts
@@ -63,7 +63,7 @@ export class M3eTooltipElement extends TooltipElementBase {
       margin: unset;
       border: unset;
       word-break: normal;
-      overflow-wrap: anywhere;
+      overflow-wrap: break-word;
       padding: var(--m3e-tooltip-padding, 0.25rem 0.5rem);
       min-width: var(--m3e-tooltip-min-width, 2.5rem);
       max-width: var(--m3e-tooltip-max-width, 12.5rem);


### PR DESCRIPTION
## Description

Prevent word breaks from affecting min-content intrinsic size when computing tooltip position against screen edge. This issue manifests on the demo page when zooming in then inspecting the Settings tooltip. Zooming in causes the tooltip to temporarily exceed the screen edge which introduces word breaks that remain after positioning.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/4c269cc2-557a-4f9f-9acd-b3ebbe77ca2c" />