### PR TITLE
fix(form-field): added padding to the textfield in outlined variant form-field to avoid overlapping text

### DIFF
--- a/packages/web/src/form-field/FormFieldElement.ts
+++ b/packages/web/src/form-field/FormFieldElement.ts
@@ -133,6 +133,11 @@ export class M3eFormFieldElement extends ReconnectedCallback(AttachInternals(Lit
       m3e-form-field[variant="outlined"] m3e-input-chip-set {
         margin-block: calc(calc(3.5rem + ${DesignToken.density.calc(-3)}) / 4);
       }
+      m3e-form-field[variant="outlined"] textarea {
+        margin-block: calc(
+          var(--m3e-form-field-label-line-height, var(--md-sys-typescale-body-small-line-height, 1rem)) / 2
+        );
+      }
       @media (prefers-reduced-motion) {
         m3e-form-field input::placeholder,
         m3e-form-field textarea::placeholder {
@@ -419,8 +424,10 @@ export class M3eFormFieldElement extends ReconnectedCallback(AttachInternals(Lit
         ${DesignToken.typescale.standard.body.small.fontSize}
       );
     }
-    :host([variant="outlined"]) .input {
-      padding: 8px 0px;
+    :host([variant="outlined"]) ::slotted(textarea) {
+      margin-block: calc(
+        var(--m3e-form-field-label-line-height, var(--md-sys-typescale-body-small-line-height, 1rem)) / 2
+      );
     }
     :host(
         [variant="outlined"][float-label="auto"]:not(:is(:state(--float-label), :--float-label)):not(

--- a/packages/web/src/form-field/FormFieldElement.ts
+++ b/packages/web/src/form-field/FormFieldElement.ts
@@ -419,6 +419,9 @@ export class M3eFormFieldElement extends ReconnectedCallback(AttachInternals(Lit
         ${DesignToken.typescale.standard.body.small.fontSize}
       );
     }
+    :host([variant="outlined"]) .input {
+      padding: 8px 0px;
+    }
     :host(
         [variant="outlined"][float-label="auto"]:not(:is(:state(--float-label), :--float-label)):not(
             :is(:state(--pressed), :--pressed)


### PR DESCRIPTION
---
Add padding to outlined variant Form-field
---

## Description

Add a padding to form field input part(outlined).

So that the text won't overlap with the label.

## Related Issue

#77 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

Before vs. After

<img width="350" height="179" alt="image" src="https://github.com/user-attachments/assets/4dcb4979-9c2c-4a7d-b0c1-516d4312b055" />

<img width="293" height="185" alt="image" src="https://github.com/user-attachments/assets/b5c12534-073d-4767-9e70-5eed1ed13154" />


## Additional Notes

Just a little fix.

Pls inform me if there are any concerns. Thks.

Nice project, by the way.