### PR TITLE
fix(slider): Update cached dimensions on pointer down event

### DIFF
--- a/packages/web/src/slider/SliderElement.ts
+++ b/packages/web/src/slider/SliderElement.ts
@@ -636,6 +636,7 @@ export class M3eSliderElement extends AttachInternals(LitElement) {
 
   /** @private */
   #handlePointerDown(e: PointerEvent): void {
+    this.#updateCachedDimensions(true);
     if (e.pointerType === "mouse" && e.button > 1) return;
     if (!this.lowerThumb || this.disabled) return;
 


### PR DESCRIPTION
---
Update cached dimensions on pointer down event
---

## Description

Update cached dimensions on pointer down event.

This solves the issue of erroneous slider position calculation after container resizing.

## Related Issue

#79 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

The screenshot has been included in the issue.

## Additional Notes

There are maybe more efficient workarounds.

But this is the most easy solution I could come up with.
