### PR TITLE
fix(docs): add accessible names to icon-button examples

### DIFF
--- a/docs/components/button-group.html
+++ b/docs/components/button-group.html
@@ -46,19 +46,19 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-button-group>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Back">
                 <m3e-icon name="arrow_back"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Forward">
                 <m3e-icon name="arrow_forward"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button width="wide" variant="filled">
+              <m3e-icon-button aria-label="Add" width="wide" variant="filled">
                 <m3e-icon name="add"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Picture in picture">
                 <m3e-icon name="picture_in_picture"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="More options">
                 <m3e-icon name="more_vert"></m3e-icon>
               </m3e-icon-button>
             </m3e-button-group>
@@ -119,11 +119,11 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-button-group>
-              <m3e-icon-button variant="filled" width="wide">
+              <m3e-icon-button aria-label="Rewind" variant="filled" width="wide">
                 <m3e-icon name="fast_rewind"></m3e-icon>
               </m3e-icon-button>
               <m3e-button variant="filled"><m3e-icon slot="icon" name="play_arrow"></m3e-icon>Play </m3e-button>
-              <m3e-icon-button variant="filled" width="wide">
+              <m3e-icon-button aria-label="Fast forward" variant="filled" width="wide">
                 <m3e-icon name="fast_forward"></m3e-icon>
               </m3e-icon-button>
             </m3e-button-group>
@@ -172,13 +172,13 @@
         <m3e-card variant="outlined" class="example">
           <div slot="content">
             <m3e-button-group variant="connected">
-              <m3e-icon-button variant="tonal" toggle>
+              <m3e-icon-button aria-label="Bold" variant="tonal" toggle>
                 <m3e-icon name="format_bold"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button variant="tonal" toggle>
+              <m3e-icon-button aria-label="Italic" variant="tonal" toggle>
                 <m3e-icon name="format_italic"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button variant="tonal" toggle>
+              <m3e-icon-button aria-label="Underline" variant="tonal" toggle>
                 <m3e-icon name="format_underlined"></m3e-icon>
               </m3e-icon-button>
             </m3e-button-group>
@@ -195,19 +195,19 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-button-group size="large">
-              <m3e-icon-button size="large">
+              <m3e-icon-button aria-label="Back" size="large">
                 <m3e-icon name="arrow_back"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button size="large">
+              <m3e-icon-button aria-label="Forward" size="large">
                 <m3e-icon name="arrow_forward"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button size="large" width="wide" variant="filled">
+              <m3e-icon-button aria-label="Add" size="large" width="wide" variant="filled">
                 <m3e-icon name="add"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button size="large">
+              <m3e-icon-button aria-label="Picture in picture" size="large">
                 <m3e-icon name="picture_in_picture"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button size="large">
+              <m3e-icon-button aria-label="More options" size="large">
                 <m3e-icon name="more_vert"></m3e-icon>
               </m3e-icon-button>
             </m3e-button-group>
@@ -261,13 +261,13 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-button-group multi>
-              <m3e-icon-button variant="tonal" toggle>
+              <m3e-icon-button aria-label="Bold" variant="tonal" toggle>
                 <m3e-icon name="format_bold"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button variant="tonal" toggle>
+              <m3e-icon-button aria-label="Italic" variant="tonal" toggle>
                 <m3e-icon name="format_italic"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button variant="tonal" toggle>
+              <m3e-icon-button aria-label="Underline" variant="tonal" toggle>
                 <m3e-icon name="format_underlined"></m3e-icon>
               </m3e-icon-button>
             </m3e-button-group>

--- a/docs/components/datepicker.html
+++ b/docs/components/datepicker.html
@@ -72,7 +72,7 @@
             <m3e-form-field variant="outlined">
               <label slot="label" for="fld1">Date Field</label>
               <input autocomplete="off" id="fld1" />
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Open calendar" slot="suffix">
                 <m3e-icon name="calendar_today"></m3e-icon>
                 <m3e-datepicker-toggle for="datepicker"></m3e-datepicker-toggle>
               </m3e-icon-button>
@@ -123,7 +123,7 @@
             <m3e-form-field variant="outlined">
               <label slot="label" for="fld8">Date Field</label>
               <input autocomplete="off" id="fld8" />
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Open calendar" slot="suffix">
                 <m3e-icon name="calendar_today"></m3e-icon>
                 <m3e-datepicker-toggle for="picker5"></m3e-datepicker-toggle>
               </m3e-icon-button>
@@ -160,7 +160,7 @@ picker.addEventListener(&quot;change&quot;, () =&gt; {
             <m3e-form-field variant="outlined">
               <label slot="label" for="fld7">Date Field</label>
               <input autocomplete="off" id="fld7" />
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Open calendar" slot="suffix">
                 <m3e-icon name="calendar_today"></m3e-icon>
                 <m3e-datepicker-toggle for="picker4"></m3e-datepicker-toggle>
               </m3e-icon-button>
@@ -187,7 +187,7 @@ picker.addEventListener(&quot;change&quot;, () =&gt; {
             <m3e-form-field variant="outlined">
               <label slot="label" for="fld6">Date Field</label>
               <input autocomplete="off" id="fld6" />
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Open calendar" slot="suffix">
                 <m3e-icon name="calendar_today"></m3e-icon>
                 <m3e-datepicker-toggle for="picker3"></m3e-datepicker-toggle>
               </m3e-icon-button>
@@ -214,7 +214,7 @@ picker.addEventListener(&quot;change&quot;, () =&gt; {
             <m3e-form-field id="range-field" variant="outlined">
               <label slot="label" for="fld5">Date Range Field</label>
               <input autocomplete="off" id="fld5" />
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Open calendar" slot="suffix">
                 <m3e-icon name="calendar_today"></m3e-icon>
                 <m3e-datepicker-toggle for="date-range"></m3e-datepicker-toggle>
               </m3e-icon-button>
@@ -271,7 +271,7 @@ picker.addEventListener(&quot;change&quot;, () =&gt; {
             <m3e-form-field variant="outlined">
               <label slot="label" for="fld4">Date Field</label>
               <input autocomplete="off" id="fld4" />
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Open calendar" slot="suffix">
                 <m3e-icon name="calendar_today"></m3e-icon>
                 <m3e-datepicker-toggle for="picker1"></m3e-datepicker-toggle>
               </m3e-icon-button>
@@ -308,7 +308,7 @@ picker.addEventListener(&quot;change&quot;, () =&gt; {
             <m3e-form-field variant="outlined">
               <label slot="label" for="fld3">Date Field</label>
               <input autocomplete="off" id="fld3" />
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Open calendar" slot="suffix">
                 <m3e-icon name="calendar_today"></m3e-icon>
                 <m3e-datepicker-toggle for="blackout-dates"></m3e-datepicker-toggle>
               </m3e-icon-button>
@@ -337,7 +337,7 @@ document.querySelector(&quot;#blackout-dates&quot;).blackoutDates = (date) =&gt;
             <m3e-form-field variant="outlined">
               <label slot="label" for="fld2">Date Field</label>
               <input autocomplete="off" id="fld2" />
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Open calendar" slot="suffix">
                 <m3e-icon name="calendar_today"></m3e-icon>
                 <m3e-datepicker-toggle for="special-dates"></m3e-datepicker-toggle>
               </m3e-icon-button>

--- a/docs/components/form-field.html
+++ b/docs/components/form-field.html
@@ -215,7 +215,7 @@
               <span slot="prefix-text">$</span>
               <input id="fld8" type="number" placeholder="0" />
               <span slot="suffix-text">.00</span>
-              <m3e-icon-button slot="suffix">
+              <m3e-icon-button aria-label="Clear" slot="suffix">
                 <m3e-icon name="clear"></m3e-icon>
               </m3e-icon-button>
             </m3e-form-field>

--- a/docs/components/icon-button.html
+++ b/docs/components/icon-button.html
@@ -43,10 +43,10 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="filled"><m3e-icon name="check"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="tonal"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="outlined"><m3e-icon name="search"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="standard"><m3e-icon name="settings"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Check" variant="filled"><m3e-icon name="check"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Search" variant="outlined"><m3e-icon name="search"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Settings" variant="standard"><m3e-icon name="settings"></m3e-icon></m3e-icon-button>
           </div>
         </m3e-card>
         <m3e-card variant="outlined" class="example">
@@ -65,10 +65,10 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="filled" shape="square"><m3e-icon name="check"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="tonal" shape="square"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="outlined" shape="square"><m3e-icon name="search"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="standard" shape="square"><m3e-icon name="settings"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Check" variant="filled" shape="square"><m3e-icon name="check"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" shape="square"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Search" variant="outlined" shape="square"><m3e-icon name="search"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Settings" variant="standard" shape="square"><m3e-icon name="settings"></m3e-icon></m3e-icon-button>
           </div>
         </m3e-card>
         <m3e-card variant="outlined" class="example">
@@ -88,11 +88,11 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="tonal" size="extra-small"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="tonal" size="small"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="tonal" size="medium"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="tonal" size="large"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="tonal" size="extra-large"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" size="extra-small"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" size="small"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" size="medium"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" size="large"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" size="extra-large"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
           </div>
         </m3e-card>
         <m3e-card variant="outlined" class="example">
@@ -112,8 +112,8 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="tonal" width="narrow"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="tonal" width="wide"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" width="narrow"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" width="wide"><m3e-icon name="add"></m3e-icon></m3e-icon-button>
           </div>
         </m3e-card>
         <m3e-card variant="outlined" class="example">
@@ -136,10 +136,10 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="filled" toggle><m3e-icon name="check"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="tonal" toggle><m3e-icon name="add"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="outlined" toggle><m3e-icon name="search"></m3e-icon></m3e-icon-button>
-            <m3e-icon-button variant="standard" toggle><m3e-icon name="settings"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Check" variant="filled" toggle><m3e-icon name="check"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Add" variant="tonal" toggle><m3e-icon name="add"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Search" variant="outlined" toggle><m3e-icon name="search"></m3e-icon></m3e-icon-button>
+            <m3e-icon-button aria-label="Settings" variant="standard" toggle><m3e-icon name="settings"></m3e-icon></m3e-icon-button>
           </div>
         </m3e-card>
         <m3e-card variant="outlined" class="example">
@@ -153,7 +153,7 @@
         <p>You can also change the icon presented for a selected toggle button using the <code>selected</code> slot.</p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="tonal" toggle>
+            <m3e-icon-button aria-label="Close" variant="tonal" toggle>
               <m3e-icon name="close"></m3e-icon>
               <m3e-icon slot="selected" name="check"></m3e-icon>
             </m3e-icon-button>
@@ -173,29 +173,29 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="filled" shape="rounded" toggle selected>
+            <m3e-icon-button aria-label="Check" variant="filled" shape="rounded" toggle selected>
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button variant="tonal" shape="rounded" toggle selected>
+            <m3e-icon-button aria-label="Add" variant="tonal" shape="rounded" toggle selected>
               <m3e-icon name="add"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button variant="outlined" shape="rounded" toggle selected>
+            <m3e-icon-button aria-label="Search" variant="outlined" shape="rounded" toggle selected>
               <m3e-icon name="search"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button variant="standard" shape="rounded" toggle selected>
+            <m3e-icon-button aria-label="Settings" variant="standard" shape="rounded" toggle selected>
               <m3e-icon name="settings"></m3e-icon>
             </m3e-icon-button>
             <br /><br />
-            <m3e-icon-button variant="filled" shape="square" toggle selected>
+            <m3e-icon-button aria-label="Check" variant="filled" shape="square" toggle selected>
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button variant="tonal" shape="square" toggle selected>
+            <m3e-icon-button aria-label="Add" variant="tonal" shape="square" toggle selected>
               <m3e-icon name="add"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button variant="outlined" shape="square" toggle selected>
+            <m3e-icon-button aria-label="Search" variant="outlined" shape="square" toggle selected>
               <m3e-icon name="search"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button variant="standard" shape="square" toggle selected>
+            <m3e-icon-button aria-label="Settings" variant="standard" shape="square" toggle selected>
               <m3e-icon name="settings"></m3e-icon>
             </m3e-icon-button>
           </div>
@@ -212,10 +212,10 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="filled" disabled>
+            <m3e-icon-button aria-label="Check" variant="filled" disabled>
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button variant="filled" disabled-interactive>
+            <m3e-icon-button aria-label="Check" variant="filled" disabled-interactive>
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
           </div>
@@ -246,7 +246,7 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button variant="tonal" href="https://www.google.com" target="_blank">
+            <m3e-icon-button aria-label="Open in new window" variant="tonal" href="https://www.google.com" target="_blank">
               <m3e-icon name="open_in_new_window"></m3e-icon>
             </m3e-icon-button>
           </div>
@@ -273,16 +273,16 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button class="density-3" variant="filled" size="extra-small">
+            <m3e-icon-button aria-label="Check" class="density-3" variant="filled" size="extra-small">
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button class="density-2" variant="filled" size="extra-small">
+            <m3e-icon-button aria-label="Check" class="density-2" variant="filled" size="extra-small">
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button class="density-1" variant="filled" size="extra-small">
+            <m3e-icon-button aria-label="Check" class="density-1" variant="filled" size="extra-small">
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button class="density-0" variant="filled" size="extra-small">
+            <m3e-icon-button aria-label="Check" class="density-0" variant="filled" size="extra-small">
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
           </div>
@@ -290,16 +290,16 @@
 
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button class="density-3" variant="filled" size="small">
+            <m3e-icon-button aria-label="Check" class="density-3" variant="filled" size="small">
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button class="density-2" variant="filled" size="small">
+            <m3e-icon-button aria-label="Check" class="density-2" variant="filled" size="small">
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button class="density-1" variant="filled" size="small">
+            <m3e-icon-button aria-label="Check" class="density-1" variant="filled" size="small">
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
-            <m3e-icon-button class="density-0" variant="filled" size="small">
+            <m3e-icon-button aria-label="Check" class="density-0" variant="filled" size="small">
               <m3e-icon name="check"></m3e-icon>
             </m3e-icon-button>
           </div>

--- a/docs/components/nav-rail.html
+++ b/docs/components/nav-rail.html
@@ -59,7 +59,7 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-nav-rail id="nav-rail">
-              <m3e-icon-button toggle>
+              <m3e-icon-button aria-label="Toggle navigation" toggle>
                 <m3e-icon name="menu"></m3e-icon>
                 <m3e-icon slot="selected" name="menu_open"></m3e-icon>
                 <m3e-nav-rail-toggle for="nav-rail"></m3e-nav-rail-toggle>

--- a/docs/components/split-button.html
+++ b/docs/components/split-button.html
@@ -54,7 +54,7 @@
           <div slot="content">
             <m3e-split-button>
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu"></m3e-menu-trigger>
               </m3e-icon-button>
@@ -95,28 +95,28 @@
           <div slot="content">
             <m3e-split-button variant="filled">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu1"></m3e-menu-trigger>
               </m3e-icon-button>
             </m3e-split-button>
             <m3e-split-button variant="tonal">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu1"></m3e-menu-trigger>
               </m3e-icon-button>
             </m3e-split-button>
             <m3e-split-button variant="outlined">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu1"></m3e-menu-trigger>
               </m3e-icon-button>
             </m3e-split-button>
             <m3e-split-button variant="elevated">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu1"></m3e-menu-trigger>
               </m3e-icon-button>
@@ -155,35 +155,35 @@
           <div slot="content">
             <m3e-split-button size="extra-small">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu2"></m3e-menu-trigger>
               </m3e-icon-button>
             </m3e-split-button>
             <m3e-split-button size="small">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu2"></m3e-menu-trigger>
               </m3e-icon-button>
             </m3e-split-button>
             <m3e-split-button size="medium">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu2"></m3e-menu-trigger>
               </m3e-icon-button>
             </m3e-split-button>
             <m3e-split-button size="large">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu2"></m3e-menu-trigger>
               </m3e-icon-button>
             </m3e-split-button>
             <m3e-split-button size="extra-large">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu2"></m3e-menu-trigger>
               </m3e-icon-button>
@@ -225,7 +225,7 @@
           <div slot="content">
             <m3e-split-button size="extra-small" class="density-3">
               <m3e-button slot="leading-button"><m3e-icon slot="icon" name="edit"></m3e-icon>Edit</m3e-button>
-              <m3e-icon-button slot="trailing-button">
+              <m3e-icon-button aria-label="More options" slot="trailing-button">
                 <m3e-icon name="keyboard_arrow_down"></m3e-icon>
                 <m3e-menu-trigger for="menu3"></m3e-menu-trigger>
               </m3e-icon-button>

--- a/docs/components/toolbar.html
+++ b/docs/components/toolbar.html
@@ -42,36 +42,36 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-toolbar variant="standard">
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Back">
                 <m3e-icon name="arrow_back"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Forward">
                 <m3e-icon name="arrow_forward"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button width="wide" variant="filled">
+              <m3e-icon-button aria-label="Add" width="wide" variant="filled">
                 <m3e-icon name="add"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Picture in picture">
                 <m3e-icon name="picture_in_picture"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="More options">
                 <m3e-icon name="more_vert"></m3e-icon>
               </m3e-icon-button>
             </m3e-toolbar>
             <m3e-toolbar variant="vibrant">
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Back">
                 <m3e-icon name="arrow_back"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Forward">
                 <m3e-icon name="arrow_forward"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button width="wide" variant="filled">
+              <m3e-icon-button aria-label="Add" width="wide" variant="filled">
                 <m3e-icon name="add"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Picture in picture">
                 <m3e-icon name="picture_in_picture"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="More options">
                 <m3e-icon name="more_vert"></m3e-icon>
               </m3e-icon-button>
             </m3e-toolbar>
@@ -110,19 +110,19 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-toolbar variant="vibrant" shape="rounded">
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Back">
                 <m3e-icon name="arrow_back"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Forward">
                 <m3e-icon name="arrow_forward"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button width="wide" variant="filled">
+              <m3e-icon-button aria-label="Add" width="wide" variant="filled">
                 <m3e-icon name="add"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Picture in picture">
                 <m3e-icon name="picture_in_picture"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="More options">
                 <m3e-icon name="more_vert"></m3e-icon>
               </m3e-icon-button>
             </m3e-toolbar>
@@ -144,19 +144,19 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-toolbar variant="vibrant" shape="rounded" elevated>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Back">
                 <m3e-icon name="arrow_back"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Forward">
                 <m3e-icon name="arrow_forward"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button width="wide" variant="filled">
+              <m3e-icon-button aria-label="Add" width="wide" variant="filled">
                 <m3e-icon name="add"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Picture in picture">
                 <m3e-icon name="picture_in_picture"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="More options">
                 <m3e-icon name="more_vert"></m3e-icon>
               </m3e-icon-button>
             </m3e-toolbar>
@@ -179,19 +179,19 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-toolbar variant="vibrant" shape="rounded" vertical>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Back">
                 <m3e-icon name="arrow_back"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Forward">
                 <m3e-icon name="arrow_forward"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button width="wide" variant="filled">
+              <m3e-icon-button aria-label="Add" width="wide" variant="filled">
                 <m3e-icon name="add"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Picture in picture">
                 <m3e-icon name="picture_in_picture"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="More options">
                 <m3e-icon name="more_vert"></m3e-icon>
               </m3e-icon-button>
             </m3e-toolbar>
@@ -218,19 +218,19 @@
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
             <m3e-toolbar class="density-3">
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Back">
                 <m3e-icon name="arrow_back"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Forward">
                 <m3e-icon name="arrow_forward"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button width="wide" variant="filled">
+              <m3e-icon-button aria-label="Add" width="wide" variant="filled">
                 <m3e-icon name="add"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="Picture in picture">
                 <m3e-icon name="picture_in_picture"></m3e-icon>
               </m3e-icon-button>
-              <m3e-icon-button>
+              <m3e-icon-button aria-label="More options">
                 <m3e-icon name="more_vert"></m3e-icon>
               </m3e-icon-button>
             </m3e-toolbar>

--- a/docs/components/tooltip.html
+++ b/docs/components/tooltip.html
@@ -44,7 +44,7 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button id="button">
+            <m3e-icon-button aria-label="Go back" id="button">
               <m3e-icon name="arrow_back"></m3e-icon>
             </m3e-icon-button>
             <m3e-tooltip for="button">Go Back</m3e-tooltip>
@@ -122,7 +122,7 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button id="button2">
+            <m3e-icon-button aria-label="Settings" id="button2">
               <m3e-icon name="settings"></m3e-icon>
             </m3e-icon-button>
             <m3e-rich-tooltip for="button2">
@@ -156,7 +156,7 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-icon-button id="button3">
+            <m3e-icon-button aria-label="Settings" id="button3">
               <m3e-icon name="settings"></m3e-icon>
             </m3e-icon-button>
             <m3e-rich-tooltip for="button3">


### PR DESCRIPTION
## Description

Thanks for m3e.

A couple `<m3e-icon-button>` examples render with no accessible name, so [assistive tech announces only "button"](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html). Docs examples get copied verbatim, so it propagates downstream.

This adds an `aria-label` to each previously-nameless icon button across 8 pages (`icon-button`, `toolbar`, `button-group`, `split-button`, `datepicker`, `tooltip`, `form-field`, `nav-rail` — 111 buttons), derived from each icon and its context. Rendered examples only; escaped code listings left raw. Purely additive.

## Related Issue
None.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

## Additional Notes
111 `aria-label` attributes across `docs/components/*.html`; no behavior change.
