### PR TITLE
docs(list): fix standard variant example

### DIFF
--- a/docs/components/list.html
+++ b/docs/components/list.html
@@ -88,7 +88,7 @@
         </p>
         <m3e-card variant="outlined" class="showcase">
           <div slot="content">
-            <m3e-list variant="outlined">
+            <m3e-list>
               <m3e-list-item>Item 1</m3e-list-item>
               <m3e-list-item>Item 2</m3e-list-item>
               <m3e-list-item>Item 3</m3e-list-item>


### PR DESCRIPTION
## Thanks

Loving the library! Here's a minor doc fix.

## Problem

In the **Variants** section of the List docs, the first (standard/default) demo renders the live list as `<m3e-list variant="outlined">`. But `outlined` is not a valid list variant — the section text states the variants are `standard` (default) and `segmented`, and this demo's own paired code sample shows `<m3e-list>` with no `variant`.

## Fix

Drop the invalid `variant="outlined"` from the live showcase so it matches its code sample and correctly demonstrates the default (**standard**) variant. One-line change in `docs/components/list.html`.

The adjacent `segmented` demo and the `<m3e-card variant="outlined">` wrappers (cards do support `outlined`) are intentionally unchanged.