### PR TITLE
feat(ripple, focus-ring): enable overlapping ripples and interruptible shape animation

### DIFF
--- a/packages/web/src/core/shared/controllers/PressedController.ts
+++ b/packages/web/src/core/shared/controllers/PressedController.ts
@@ -41,6 +41,7 @@ export class PressedController extends MonitorControllerBase {
   /** @private */ readonly #filter?: PressedControllerFilterCallback;
   /** @private */ readonly #isPressedKey?: (key: string) => boolean;
   /** @private */ readonly #pressedTargets = new Map<HTMLElement, number>();
+  /** @private */ readonly #releaseTimeouts = new Map<HTMLElement, ReturnType<typeof setTimeout>>();
   /** @private */ readonly #minPressedDuration: number;
 
   /** @private */ readonly #pointerDownHandler = (e: PointerEvent) => this.#handlePointerDown(e);
@@ -80,6 +81,10 @@ export class PressedController extends MonitorControllerBase {
     document.removeEventListener("touchcancel", this.#touchEndHandler, { capture: this.#capture });
 
     super.hostDisconnected();
+    for (const id of this.#releaseTimeouts.values()) {
+      clearTimeout(id);
+    }
+    this.#releaseTimeouts.clear();
     this.#pressedTargets.clear();
   }
 
@@ -101,6 +106,9 @@ export class PressedController extends MonitorControllerBase {
       target.removeEventListener("keydown", this.#keyDownHandler, { capture: this.#capture });
       target.removeEventListener("keyup", this.#keyUpHandler, { capture: this.#capture });
     }
+
+    this.#clearReleaseTimeout(target);
+    this.#pressedTargets.delete(target);
   }
 
   /** @private */
@@ -110,10 +118,9 @@ export class PressedController extends MonitorControllerBase {
 
     for (const target of e.composedPath()) {
       if (target instanceof HTMLElement && this.isObserving(target)) {
-        if (!this.#pressedTargets.has(target)) {
-          this.#pressedTargets.set(target, performance.now());
-          this.#callback(true, { x: e.x, y: e.y }, target);
-        }
+        this.#clearReleaseTimeout(target);
+        this.#pressedTargets.set(target, performance.now());
+        this.#callback(true, { x: e.x, y: e.y }, target);
         break;
       }
     }
@@ -141,26 +148,31 @@ export class PressedController extends MonitorControllerBase {
         e.preventDefault();
       }
 
-      if (!this.#pressedTargets.has(target)) {
-        this.#pressedTargets.set(target, performance.now());
-        const bounds = target.getBoundingClientRect();
-        this.#callback(true, { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }, target);
-      }
+      this.#clearReleaseTimeout(target);
+      this.#pressedTargets.set(target, performance.now());
+      const bounds = target.getBoundingClientRect();
+      this.#callback(true, { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }, target);
     }
   }
 
   /** @private */
   #handleKeyUp(e: KeyboardEvent): void {
-    const target = e.target as HTMLElement;
+    if (e.target !== e.currentTarget) return;
+    const target = e.currentTarget as HTMLElement;
 
     if (this.#pressedTargets.has(target) && this.#isPressedKey?.(e.key)) {
+      this.#clearReleaseTimeout(target);
       const remainingTime = this.#minPressedDuration - (performance.now() - this.#pressedTargets.get(target)!);
       const bounds = target.getBoundingClientRect();
       if (remainingTime > 0) {
-        setTimeout(() => {
-          this.#pressedTargets.delete(target);
-          this.#callback(false, { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }, target);
-        }, remainingTime);
+        this.#releaseTimeouts.set(
+          target,
+          setTimeout(() => {
+            this.#pressedTargets.delete(target);
+            this.#releaseTimeouts.delete(target);
+            this.#callback(false, { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }, target);
+          }, remainingTime),
+        );
       } else {
         this.#pressedTargets.delete(target);
         this.#callback(false, { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 }, target);
@@ -171,16 +183,30 @@ export class PressedController extends MonitorControllerBase {
   /** @private */
   #clearPressedTargets(x: number, y: number): void {
     for (const target of this.#pressedTargets) {
+      this.#clearReleaseTimeout(target[0]);
       const remainingTime = this.#minPressedDuration - (performance.now() - target[1]);
       if (remainingTime > 0) {
-        setTimeout(() => {
-          this.#pressedTargets.delete(target[0]);
-          this.#callback(false, { x, y }, target[0]);
-        }, remainingTime);
+        this.#releaseTimeouts.set(
+          target[0],
+          setTimeout(() => {
+            this.#pressedTargets.delete(target[0]);
+            this.#releaseTimeouts.delete(target[0]);
+            this.#callback(false, { x, y }, target[0]);
+          }, remainingTime),
+        );
       } else {
         this.#pressedTargets.delete(target[0]);
         this.#callback(false, { x, y }, target[0]);
       }
+    }
+  }
+
+  /** @private */
+  #clearReleaseTimeout(target: HTMLElement): void {
+    const id = this.#releaseTimeouts.get(target);
+    if (id !== undefined) {
+      clearTimeout(id);
+      this.#releaseTimeouts.delete(target);
     }
   }
 }

--- a/packages/web/src/core/shared/primitives/FocusRingElement.ts
+++ b/packages/web/src/core/shared/primitives/FocusRingElement.ts
@@ -4,6 +4,7 @@ import { property, query } from "lit/decorators.js";
 import { FocusController } from "../controllers";
 import { HtmlFor, Role } from "../mixins";
 import { customElement } from "../decorators";
+import { DesignToken } from "../tokens";
 
 import { FocusRingToken } from "./FocusRingToken";
 
@@ -70,11 +71,14 @@ export class M3eFocusRingElement extends HtmlFor(Role(LitElement, "none")) {
       border-radius: inherit;
       z-index: 1;
       outline-color: ${FocusRingToken.color};
-      outline-width: ${FocusRingToken.thickness};
+      outline-style: none;
+      outline-width: 0;
       visibility: ${FocusRingToken.visibility};
+      transition: outline-width ${DesignToken.motion.spring.fastSpatial}, outline-offset ${DesignToken.motion.spring.fastSpatial};
     }
     .outline.visible {
       outline-style: solid;
+      outline-width: ${FocusRingToken.thickness};
     }
     :host(:not([inward])) .outline {
       outline-offset: ${FocusRingToken.outwardOffset};
@@ -82,29 +86,12 @@ export class M3eFocusRingElement extends HtmlFor(Role(LitElement, "none")) {
     :host([inward]) .outline {
       outline-offset: calc(${FocusRingToken.inwardOffset} - ${FocusRingToken.thickness});
     }
-    :host(:not([inward])) .outline.visible {
-      animation: grow-shrink ${FocusRingToken.duration};
-    }
     :host([inward]) .outline.visible {
-      animation: shrink-grow ${FocusRingToken.duration};
-    }
-    @keyframes grow-shrink {
-      50% {
-        outline-width: calc(${FocusRingToken.thickness} * ${FocusRingToken.growthFactor});
-      }
-    }
-    @keyframes shrink-grow {
-      50% {
-        outline-offset: calc(
-          ${FocusRingToken.inwardOffset} - calc(${FocusRingToken.thickness} * ${FocusRingToken.growthFactor})
-        );
-        outline-width: calc(${FocusRingToken.thickness} * ${FocusRingToken.growthFactor});
-      }
+      outline-offset: ${FocusRingToken.inwardOffset};
     }
     @media (prefers-reduced-motion) {
-      :host(:not([inward])) .outline.visible,
-      :host([inward]) .outline.visible {
-        animation: none;
+      .outline {
+        transition: none;
       }
     }
     @media (forced-colors: active) {
@@ -137,12 +124,12 @@ export class M3eFocusRingElement extends HtmlFor(Role(LitElement, "none")) {
 
   /** Launches a manual focus ring. */
   show(): void {
-    this._outline?.classList.toggle("visible", true);
+    this._outline?.classList.add("visible");
   }
 
   /** Hides the focus ring. */
   hide(): void {
-    this._outline?.classList.toggle("visible", false);
+    this._outline?.classList.remove("visible");
   }
 
   /** @inheritdoc */

--- a/packages/web/src/core/shared/primitives/RippleElement.ts
+++ b/packages/web/src/core/shared/primitives/RippleElement.ts
@@ -113,10 +113,10 @@ export class M3eRippleElement extends HtmlFor(Role(LitElement, "none")) {
     }
   `;
 
-  /** @private */ #ripple: HTMLElement | null = null;
+  /** @private */ readonly #ripples: Set<HTMLElement> = new Set();
   /** @private */ readonly #pressedController = new PressedController(this, {
     target: null,
-    minPressedDuration: 225,
+    minPressedDuration: 0,
     isPressedKey: (key) => key === " ",
     callback: (pressed, { x, y }) => this.#handlePressedChange(pressed, x, y),
   });
@@ -149,7 +149,7 @@ export class M3eRippleElement extends HtmlFor(Role(LitElement, "none")) {
 
   /** Whether the ripple is currently visible to the user. */
   get visible() {
-    return this.#ripple !== null;
+    return this.#ripples.size > 0;
   }
 
   /**
@@ -159,8 +159,6 @@ export class M3eRippleElement extends HtmlFor(Role(LitElement, "none")) {
    * @param {boolean} [persistent=false] Whether the ripple will persist until hidden.
    */
   show(x: number, y: number, persistent: boolean = false): void {
-    this.#destroyRipple();
-
     const bounds = this.getBoundingClientRect();
     if (this.centered) {
       x = bounds.left + bounds.width / 2;
@@ -178,26 +176,37 @@ export class M3eRippleElement extends HtmlFor(Role(LitElement, "none")) {
     const offsetX = x - bounds.left;
     const offsetY = y - bounds.top;
 
-    this.#ripple = document.createElement("div");
-    this.#ripple.classList.add("ripple");
+    const ripple = document.createElement("div");
+    ripple.classList.add("ripple");
     if (persistent) {
-      this.#ripple.classList.add("persistent");
+      ripple.classList.add("persistent");
     }
 
-    this.#ripple.style.left = `${offsetX - radius}px`;
-    this.#ripple.style.top = `${offsetY - radius}px`;
-    this.#ripple.style.width = `${radius * 2}px`;
-    this.#ripple.style.height = `${radius * 2}px`;
+    ripple.style.left = `${offsetX - radius}px`;
+    ripple.style.top = `${offsetY - radius}px`;
+    ripple.style.width = `${radius * 2}px`;
+    ripple.style.height = `${radius * 2}px`;
 
-    this.#ripple.addEventListener("animationend", () => this.#handleAnimationEnd(persistent), { once: true });
-    this.#ripple.addEventListener("transitionend", () => this.#destroyRipple(), { once: true });
+    ripple.addEventListener("animationend", () => this.#handleAnimationEnd(ripple, persistent), { once: true });
+    ripple.addEventListener("transitionend", (e) => {
+      if (e.propertyName === "opacity") {
+        this.#destroyRipple(ripple);
+      }
+    }, { once: true });
 
-    this.shadowRoot?.appendChild(this.#ripple);
+    if (!this.shadowRoot) {
+      this.#ripples.delete(ripple);
+      return;
+    }
+    this.#ripples.add(ripple);
+    this.shadowRoot.appendChild(ripple);
   }
 
   /** Manually hides the ripple. */
   hide(): void {
-    this.#ripple?.classList.add("exit");
+    for (const ripple of this.#ripples) {
+      ripple.classList.add("exit");
+    }
   }
 
   /** @inheritdoc */
@@ -236,17 +245,24 @@ export class M3eRippleElement extends HtmlFor(Role(LitElement, "none")) {
   }
 
   /** @private */
-  #destroyRipple(): void {
-    this.#ripple?.remove();
-    this.#ripple = null;
+  #destroyRipple(ripple?: HTMLElement): void {
+    if (ripple) {
+      ripple.remove();
+      this.#ripples.delete(ripple);
+    } else {
+      for (const r of this.#ripples) {
+        r.remove();
+      }
+      this.#ripples.clear();
+    }
   }
 
   /** @private */
-  #handleAnimationEnd(persistent: boolean): void {
+  #handleAnimationEnd(ripple: HTMLElement, persistent: boolean): void {
     if (persistent) {
-      this.#ripple?.classList.add("pressed");
+      ripple.classList.add("pressed");
     } else {
-      this.hide();
+      ripple.classList.add("exit");
     }
   }
 


### PR DESCRIPTION
## Description

- discovered that ripple couldn't overlap older ones when clicking fast, fixed it
- made focus ring shape animation interruptible (keyframes → CSS transition)
- tracked release timeouts in PressedController to prevent stale callbacks

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

https://github.com/user-attachments/assets/4fdd52a7-39c5-49fa-b2ea-b1b0017bd08b

## Additional

<details>
<summary>not so related to this pr, feel free to expand</summary>
btw i used ai to modify the `docs` folder to build a `local-demo` for local preview and debugging, no need to upload it, do u need it?
<img width="1373" height="327" alt="screenshot_1785133461897" src="https://github.com/user-attachments/assets/0367de38-bb0d-4ea7-8472-445cbf0ee319" />
</details>
