### PR TITLE
fix(cem): correct @slot/@fires/@tag JSDoc so custom-elements.json matches the components

### DIFF
--- a/packages/web/src/fab-menu/FabMenuItemElement.ts
+++ b/packages/web/src/fab-menu/FabMenuItemElement.ts
@@ -39,7 +39,7 @@ import type { M3eFabMenuElement } from "./FabMenuElement";
  * </m3e-fab-menu>
  * ```
  *
- * @tag m3e-menu-item
+ * @tag m3e-fab-menu-item
  *
  * @slot - Renders the label of the item.
  * @slot icon - Renders an icon before the items's label.

--- a/packages/web/src/form-field/FormFieldElement.ts
+++ b/packages/web/src/form-field/FormFieldElement.ts
@@ -67,6 +67,7 @@ import { FloatLabelType } from "./FloatLabelType";
  * @tag m3e-form-field
  *
  * @slot - Renders the control of the field.
+ * @slot label - Renders the label of the field.
  * @slot prefix - Renders content before the fields's control.
  * @slot prefix-text - Renders text before the fields's control.
  * @slot suffix - Renders content after the fields's control.

--- a/packages/web/src/list/ListItemElement.ts
+++ b/packages/web/src/list/ListItemElement.ts
@@ -45,9 +45,12 @@ import { ListItemContentType } from "./ListItemContentType";
  *
  * @slot - Renders the content of the list item.
  * @slot leading - Renders the leading content of the list item.
+ * @slot leading-icon - Renders a leading icon of the list item (fallback within the leading slot).
  * @slot overline - Renders the overline of the list item.
  * @slot supporting-text - Renders the supporting text of the list item.
  * @slot trailing - Renders the trailing content of the list item.
+ * @slot trailing-supporting-text - Renders trailing supporting text of the list item (fallback within the trailing slot).
+ * @slot trailing-icon - Renders a trailing icon of the list item (fallback within the trailing slot).
  *
  * @cssprop --m3e-list-item-between-space - Horizontal gap between elements.
  * @cssprop --m3e-list-item-leading-space - Horizontal padding for the leading side.

--- a/packages/web/src/option/OptionElement.ts
+++ b/packages/web/src/option/OptionElement.ts
@@ -32,6 +32,8 @@ import { typeaheadLabel } from "@m3e/web/core/a11y";
  *
  * @slot - Renders the label of the option.
  *
+ * @fires state-change - Emitted when the option's selected or disabled state changes.
+ *
  * @attr disabled - Whether the element is disabled.
  * @attr disable-highlight - Whether text highlighting is disabled.
  * @attr highlight-mode - The mode in which to highlight a term.

--- a/packages/web/src/option/OptionPanelElement.ts
+++ b/packages/web/src/option/OptionPanelElement.ts
@@ -30,6 +30,8 @@ import { OptionPanelState } from "./OptionPanelState";
  * @tag m3e-option-panel
  *
  * @slot - Renders the contents of the list.
+ * @slot no-data - Renders content shown when there is no data.
+ * @slot loading - Renders content shown while the panel is loading.
  *
  * @fires beforetoggle - Dispatched before the toggle state changes.
  * @fires toggle - Dispatched after the toggle state has changed.

--- a/packages/web/src/search/SearchBarElement.ts
+++ b/packages/web/src/search/SearchBarElement.ts
@@ -35,6 +35,7 @@ import { SearchBarLightDomStyle, SearchBarStyle } from "./styles";
  * @slot leading - Renders content before the input of the bar.
  * @slot input - Renders the input of the bar.
  * @slot trailing - Renders content after the input of the bar.
+ * @slot clear-icon - Overrides the default clear icon of the bar.
  *
  * @fires clear - Dispatched when the search term is cleared.
  *

--- a/packages/web/src/search/SearchViewElement.ts
+++ b/packages/web/src/search/SearchViewElement.ts
@@ -67,6 +67,9 @@ import "./SearchBarElement";
  * @slot open-trailing - When open, renders content after the input of the view.
  * @slot closed-leading - When closed, renders content before the input of the view.
  * @slot closed-trailing - When closed, renders content after the input of the view.
+ * @slot search-icon - Overrides the default search icon of the view.
+ * @slot close-icon - Overrides the default close icon shown while the view is open.
+ * @slot clear-icon - Overrides the default clear icon of the view.
  *
  * @fires clear - Dispatched when the search term is cleared.
  * @fires query - Dispatched when the view is opened or when the user modifies the search term.

--- a/packages/web/src/stepper/StepPanelElement.ts
+++ b/packages/web/src/stepper/StepPanelElement.ts
@@ -54,7 +54,7 @@ import { customElement, Role } from "@m3e/web/core";
  * @tag m3e-step-panel
  *
  * @slot - Renders the content of the panel.
- * @slot actions- Renders the actions bar of the panel.
+ * @slot actions - Renders the actions bar of the panel.
  *
  * @cssprop --m3e-step-panel-padding - Padding inside the step panel container, defining internal spacing around content.
  * @cssprop --m3e-step-panel-spacing - Vertical gap between stacked elements within the step panel.


### PR DESCRIPTION
## Summary

Several JSDoc annotations don't match the components' real implementation, so the generated `custom-elements.json` misrepresents the public API. Tools that consume the CEM (docs viewers, typed-binding generators) never see these slots/events, or file a component under the wrong tag.

**Annotation-only change — no runtime code is touched.** Each fix matches an existing declaration in the component's own source.

## Changes

**Missing `@slot`** (each matches a `<slot name="…">` in the component's render):

| Component | Added |
|---|---|
| `m3e-form-field` | `label` — render `<slot name="label">`, the class's own `@example` (`<label slot="label" for=…>`), and `::slotted([slot="label"])` CSS all use it |
| `m3e-list-item` | `leading-icon`, `trailing-icon`, `trailing-supporting-text` (fallback slots nested in leading/trailing) |
| `m3e-search-view` | `search-icon`, `close-icon`, `clear-icon` (icon-override slots with a default SVG) |
| `m3e-search-bar` | `clear-icon` (icon-override slot) |
| `m3e-option-panel` | `no-data`, `loading` (content slots) |

**`@slot` typo:** `m3e-step-panel` — `@slot actions-` → `@slot actions` (render uses `name="actions"`).

**Missing `@fires`:** `m3e-option` — `state-change` (`dispatchEvent(new CustomEvent("state-change", { bubbles: true }))`).

**Wrong `@tag`:** `FabMenuItemElement` is `@customElement("m3e-fab-menu-item")` but its JSDoc says `@tag m3e-menu-item` (a copy-paste from `MenuItemElement`), so the element misfiles under `m3e-menu-item` in the CEM. Corrected.

## How these were found

Auditing a project that generates type-safe Elm bindings from `@m3e/web`'s CEM, we hit `m3e-form-field`: no `label` slot in the manifest, so the binding couldn't express it — yet the component supports `<label slot="label">` (its own `@example` shows it). A systematic diff of each component's rendered `<slot name>` against its declared `@slot` tags (cross-checked with a headless-browser shadow-DOM render) surfaced the rest.

## Noted, not included

`SplitPaneElement.valueFormatter` and `TimepickerElement.blackoutTimes` are `@property()` on function types → Lit registers a lowercased, unsettable attribute. They'd be more accurate as `@property({ attribute: false })`; left out of this annotation-only PR — happy to send separately.
