### PR TITLE
fix(card, autocomplete): scope slot-presence checks to direct children

### DIFF
--- a/packages/web/src/autocomplete/AutocompleteElement.ts
+++ b/packages/web/src/autocomplete/AutocompleteElement.ts
@@ -241,12 +241,12 @@ export class M3eAutocompleteElement extends HtmlFor(LitElement) {
 
   /** @private */
   get #hasNoDataSlot(): boolean {
-    return (this.#clone?.querySelector("[slot='no-data']") ?? null) !== null;
+    return (this.#clone?.querySelector(":scope > [slot='no-data']") ?? null) !== null;
   }
 
   /** @private */
   get #hasLoadingSlot(): boolean {
-    return (this.#clone?.querySelector("[slot='loading']") ?? null) !== null;
+    return (this.#clone?.querySelector(":scope > [slot='loading']") ?? null) !== null;
   }
 
   /** @private */

--- a/packages/web/src/card/CardElement.ts
+++ b/packages/web/src/card/CardElement.ts
@@ -256,7 +256,7 @@ export class M3eCardElement extends KeyboardClick(
   #handleContentSlotChange(): void {
     this.shadowRoot
       ?.querySelector(".base")
-      ?.classList.toggle("has-content", this.querySelector("[slot='content']") !== null);
+      ?.classList.toggle("has-content", this.querySelector(":scope > [slot='content']") !== null);
   }
 
   /** @private */
@@ -265,7 +265,7 @@ export class M3eCardElement extends KeyboardClick(
       ?.querySelector(".base")
       ?.classList.toggle(
         "has-default",
-        hasAssignedNodes(e.target as HTMLSlotElement) && this.querySelector("[slot='content']") === null,
+        hasAssignedNodes(e.target as HTMLSlotElement) && this.querySelector(":scope > [slot='content']") === null,
       );
   }
 


### PR DESCRIPTION
## Context

This library is great, and I've been absolutely loving it. 
However, I did encounter this unexpected behavior where content slots are not just looking at direct children, but ALL descendants. This PR should fix that issue. Thanks again for this wonderful library.

## Summary
- `m3e-card`'s `has-content`/`has-default` detection uses `this.querySelector("[slot='content']")`, which searches the *entire* light-DOM subtree rather than just direct children. Any unrelated nested descendant that happens to carry `slot="content"` (e.g. a child component's own named slot) makes the card think its `content` slot is populated, so content padding is applied even when nothing is assigned to `content` — including cards that only use the default (unpadded) slot.
- `m3e-autocomplete`'s `#hasNoDataSlot`/`#hasLoadingSlot` have the same unscoped-`querySelector` pattern against its cloned light DOM.
- Fix: scope each check with `:scope > [slot='...']` so only direct children are considered.

## Test plan
- [x] `npm run build` (workspace) — clean
- [x] `npx eslint ./src/card/CardElement.ts ./src/autocomplete/AutocompleteElement.ts` — clean
- [x] Manual repro via Playwright: `m3e-card` with only default-slot content, containing a nested descendant carrying `slot="content"` — before fix: `.base` gets `has-content` (wrong, padding applied); after fix: `.base` gets `has-default` only (correct, no padding)