### PR TITLE
fix(select,autocomplete): mount option panel in shadow root instead of light DOM

### DIFF
--- a/packages/web/src/autocomplete/AutocompleteElement.ts
+++ b/packages/web/src/autocomplete/AutocompleteElement.ts
@@ -209,6 +209,12 @@ export class M3eAutocompleteElement extends HtmlFor(LitElement) {
 
   /**
    * Class or list of classes to be applied to the autocomplete's overlay panel.
+   *
+   * Note: the panel is rendered inside this component's shadow root, so a page-level
+   * stylesheet's plain class selector cannot reach it due to Shadow DOM style encapsulation.
+   * Use the documented `@cssprop` custom properties on the panel/floating-panel classes
+   * for theming instead.
+   *
    * @default ""
    */
   @property({ attribute: "panel-class" }) panelClass = "";
@@ -705,7 +711,7 @@ export class M3eAutocompleteElement extends HtmlFor(LitElement) {
 
     this.#updateMenuState(this.#menu, count);
 
-    (this.#formField ?? this.#input).insertAdjacentElement("afterend", this.#menu);
+    this.shadowRoot?.appendChild(this.#menu);
 
     this.#input.setAttribute("aria-controls", this.#menuId);
     this.#input.setAttribute("aria-owns", this.#menuId);

--- a/packages/web/src/autocomplete/AutocompleteElement.ts
+++ b/packages/web/src/autocomplete/AutocompleteElement.ts
@@ -210,11 +210,6 @@ export class M3eAutocompleteElement extends HtmlFor(LitElement) {
   /**
    * Class or list of classes to be applied to the autocomplete's overlay panel.
    *
-   * Note: the panel is rendered inside this component's shadow root, so a page-level
-   * stylesheet's plain class selector cannot reach it due to Shadow DOM style encapsulation.
-   * Use the documented `@cssprop` custom properties on the panel/floating-panel classes
-   * for theming instead.
-   *
    * @default ""
    */
   @property({ attribute: "panel-class" }) panelClass = "";
@@ -711,7 +706,7 @@ export class M3eAutocompleteElement extends HtmlFor(LitElement) {
 
     this.#updateMenuState(this.#menu, count);
 
-    this.shadowRoot?.appendChild(this.#menu);
+    document.documentElement.appendChild(this.#menu);
 
     this.#input.setAttribute("aria-controls", this.#menuId);
     this.#input.setAttribute("aria-owns", this.#menuId);

--- a/packages/web/src/select/SelectElement.ts
+++ b/packages/web/src/select/SelectElement.ts
@@ -213,11 +213,6 @@ export class M3eSelectElement
   /**
    * Class or list of classes to be applied to the select's overlay panel.
    *
-   * Note: the panel is rendered inside this component's shadow root, so a page-level
-   * stylesheet's plain class selector cannot reach it due to Shadow DOM style encapsulation.
-   * Use the documented `@cssprop` custom properties on the panel/floating-panel classes
-   * for theming instead.
-   *
    * @default ""
    */
   @property({ attribute: "panel-class" }) panelClass = "";
@@ -647,7 +642,7 @@ export class M3eSelectElement
       this.#menu.replaceChildren(...this.#clone.childNodes);
     }
 
-    this.shadowRoot?.appendChild(this.#menu);
+    document.documentElement.appendChild(this.#menu);
 
     this.ariaExpanded = "true";
     this.setAttribute("aria-controls", this.#listId);

--- a/packages/web/src/select/SelectElement.ts
+++ b/packages/web/src/select/SelectElement.ts
@@ -212,6 +212,12 @@ export class M3eSelectElement
 
   /**
    * Class or list of classes to be applied to the select's overlay panel.
+   *
+   * Note: the panel is rendered inside this component's shadow root, so a page-level
+   * stylesheet's plain class selector cannot reach it due to Shadow DOM style encapsulation.
+   * Use the documented `@cssprop` custom properties on the panel/floating-panel classes
+   * for theming instead.
+   *
    * @default ""
    */
   @property({ attribute: "panel-class" }) panelClass = "";
@@ -641,7 +647,7 @@ export class M3eSelectElement
       this.#menu.replaceChildren(...this.#clone.childNodes);
     }
 
-    (this.#formField ?? this).insertAdjacentElement("afterend", this.#menu);
+    this.shadowRoot?.appendChild(this.#menu);
 
     this.ariaExpanded = "true";
     this.setAttribute("aria-controls", this.#listId);


### PR DESCRIPTION
## You're speedy!

Thanks for merging the prior PR! 
This PR aims to add a little VDOM safety.

## Problem

`m3e-select` and `m3e-autocomplete` dynamically create their floating option panel and insert it into light DOM as a sibling of the trigger, via `insertAdjacentElement("afterend", ...)`. That insertion point lives inside whatever element the *consuming application's* own UI framework owns and renders.

Any framework that diffs a parent's children positionally or by key (Elm, React, Vue, etc.) can have this foreign node corrupt that diff: a node appearing mid-list shifts every later sibling's index, so the framework patches the wrong node or crashes outright. This is a general web-components/framework-interop hazard, not specific to any one app.

1. control (framework-owned parent) 
2. input (user opens menu)
3. append (raw DOM mutation the framework doesn’t know about)
4. desync (framework’s model and the real DOM now disagree on child count/order)
5. crash (on the framework’s next diff of that parent, triggered by anything, not necessarily the select itself)

## Fix

Mount the panel into the component's own shadow root instead of light DOM. This makes it structurally unreachable by any framework's child diffing, by construction — the framework never sees a shadow tree it doesn't own.

Positioning is unaffected: `M3eFloatingPanelElement.show()` already positions the panel via absolute pixel coordinates set as inline styles, independent of where it sits in the tree, and `popover="manual"` still promotes it to the browser's top layer from inside a shadow root, escaping ancestor `overflow: hidden` exactly as before.

## Tradeoff

`panelClass`/`panel-class` can no longer be targeted by a page-level global CSS class selector once the panel lives in shadow DOM — that's fundamental Shadow DOM style encapsulation, not a regression. Added a short JSDoc note on both properties pointing at the existing `@cssprop` custom properties as the supported theming path instead.

## Testing

- `npm run build` / `npm run lint` / `npm run cem` — all pass, no unexpected API surface change
- Manual browser verification: opened/selected/closed/reopened both components repeatedly with zero console errors, confirmed the panel renders and positions correctly, and confirmed via `shadowRoot.querySelector('m3e-option-panel')` that the panel lives in shadow DOM and is unreachable from light DOM.
