### PR TITLE
feat(snackbar): add reflected open attribute for declarative visibility

### DIFF
--- a/packages/web/src/snackbar/README.md
+++ b/packages/web/src/snackbar/README.md
@@ -24,6 +24,25 @@ M3eSnackbar.open("File deleted", "Undo", {
 });
 ```
 
+The following example illustrates declarative usage via the `open` attribute, suitable for attribute-driven renderers such as Elm or hypermedia frameworks. Setting the attribute shows the snackbar; removing it hides it. The attribute is automatically cleared when the snackbar is dismissed (by auto-dismiss timeout, action click, or close button), so the DOM stays truthful.
+
+```html
+<!-- Show the snackbar declaratively -->
+<m3e-snackbar open dismissible>File deleted</m3e-snackbar>
+
+<!-- Toggle visibility in JavaScript -->
+<script>
+  const snackbar = document.querySelector("m3e-snackbar");
+  // Show
+  snackbar.open = true;
+  // Or equivalently: snackbar.setAttribute("open", "");
+
+  // Hide
+  snackbar.open = false;
+  // Or equivalently: snackbar.removeAttribute("open");
+</script>
+```
+
 ## 📖 API Reference
 
 ### 🛠️ Snackbar Service
@@ -52,6 +71,7 @@ This section details the attributes, slots and CSS custom properties available f
 | `close-label` | `string`  | `"Close"` | The accessible label given to the button used to dismiss the snackbar.                     |
 | `dismissible` | `boolean` | `false`   | Whether a button is presented that can be used to close the snackbar.                      |
 | `duration`    | `number`  | `3000`    | The length of time, in milliseconds, to wait before automatically dismissing the snackbar. |
+| `open`        | `boolean` | `false`   | Whether the snackbar is open.                                                              |
 
 #### 🧩 Slots
 

--- a/packages/web/src/snackbar/SnackbarElement.ts
+++ b/packages/web/src/snackbar/SnackbarElement.ts
@@ -19,6 +19,7 @@ import "@m3e/web/icon-button";
  * @attr close-label - The accessible label given to the button used to dismiss the snackbar.
  * @attr dismissible - Whether a button is presented that can be used to close the snackbar.
  * @attr duration - The length of time, in milliseconds, to wait before automatically dismissing the snackbar.
+ * @attr open - Whether the snackbar is open.
  *
  * @fires beforetoggle - Dispatched before the toggle state changes.
  * @fires toggle - Dispatched after the toggle state has changed.
@@ -187,6 +188,7 @@ export class M3eSnackbarElement extends Role(LitElement, "status") {
   /** @private */ #timeoutId = -1;
   /** @private */ #actionTaken = false;
   /** @private */ readonly #beforeToggleHandler = (e: ToggleEvent) => this.#handleBeforeToggle(e);
+  /** @private */ readonly #toggleHandler = (e: ToggleEvent) => { this.open = e.newState === "open"; };
 
   /** The currently open snackbar. */
   static get current(): M3eSnackbarElement | null {
@@ -212,6 +214,12 @@ export class M3eSnackbarElement extends Role(LitElement, "status") {
   @property({ type: Boolean, reflect: true }) dismissible = false;
 
   /**
+   * Whether the snackbar is open.
+   * @default false
+   */
+  @property({ type: Boolean, reflect: true }) open = false;
+
+  /**
    * The accessible label given to the button used to dismiss the snackbar.
    * @default "Close"
    */
@@ -227,6 +235,7 @@ export class M3eSnackbarElement extends Role(LitElement, "status") {
     super.connectedCallback();
 
     this.addEventListener("beforetoggle", this.#beforeToggleHandler);
+    this.addEventListener("toggle", this.#toggleHandler);
     this.setAttribute("popover", "manual");
     this.ariaLive = "polite";
   }
@@ -236,6 +245,7 @@ export class M3eSnackbarElement extends Role(LitElement, "status") {
     super.disconnectedCallback();
 
     this.removeEventListener("beforetoggle", this.#beforeToggleHandler);
+    this.removeEventListener("toggle", this.#toggleHandler);
   }
 
   /** @inheritdoc */
@@ -247,8 +257,13 @@ export class M3eSnackbarElement extends Role(LitElement, "status") {
   }
 
   /** @inheritdoc */
-  protected override updated(_changedProperties: PropertyValues): void {
-    super.updated(_changedProperties);
+  protected override updated(changed: PropertyValues): void {
+    super.updated(changed);
+
+    if (changed.has("open")) {
+      if (this.open && !this.matches(":popover-open")) this.showPopover();
+      else if (!this.open && this.matches(":popover-open")) this.hidePopover();
+    }
 
     // After render, compute the (unscaled) height of the snackbar in order
     // to properly position it relative to the viewport.


### PR DESCRIPTION
# Context

Hello again! Still using the library, still loving it. 

This PR provides a nice-to-have for elm devs because we don't have access to web component methods, we rely on declarative APIs when using web components. This is the only component afaict that doesn't have some declarative interface mechanism. This PR aims to mend that gap. 

If it doesn't jive with your vision, that's fine, I can build a wrapper for the team to use, but I figured I'd add this PR to see if it's something you'd be open to. (no pun intended.)

## Summary
Adds a reflected boolean `open` attribute to `<m3e-snackbar>`, allowing visibility to be controlled declaratively (set/remove the attribute, or the `.open` property) in addition to the existing imperative `showPopover()` and `M3eSnackbar` service API. This unblocks attribute-driven consumers.

## Behavior
- Setting `open` (or `.open = true`) shows the snackbar; removing it hides it.
- `open` reflects reality: auto-dismiss (`duration`), the action/close button, and singleton eviction all clear the attribute automatically, because reflection is anchored to the popover `toggle` event rather than the property setter.
- Declarative opens participate in the existing "one snackbar at a time" singleton — no bypass, and no change to the `M3eSnackbar` service.

## Implementation
- New `@property({ type: Boolean, reflect: true }) open = false` (mirrors the existing `dismissible`).
- `updated()` drives `showPopover()`/`hidePopover()` on `open` change, guarded by a `:popover-open` state check (native popover throws on show-when-open / hide-when-closed).
- A `toggle` listener reflects popover state back into `open`; Lit's dirty-check prevents a feedback loop.
- Pattern mirrors `bottom-sheet` (popover + singleton + reflected `open`).
- `@attr open` JSDoc added so the generated Custom Elements Manifest stays accurate.
- README Attributes table + a declarative usage example added.

## Verification
`npm run all` (build + cem + lint) passes with zero errors or warnings. No automated test suite exists in the repo and browser verification was not performed.