### PR TITLE
fix(form-field): keep pseudo-label in sync with slotted label text

### DIFF
--- a/packages/web/src/form-field/FormFieldElement.ts
+++ b/packages/web/src/form-field/FormFieldElement.ts
@@ -640,6 +640,19 @@ export class M3eFormFieldElement extends ReconnectedCallback(AttachInternals(Lit
   /** @private */ @query(".suffix") private readonly _suffix!: HTMLElement;
   /** @private */ @query(".error") private readonly _error!: HTMLElement;
   /** @private */ @query(".hint") private readonly _hint!: HTMLElement;
+  /** @private */ @query('slot[name="label"]') private readonly _labelSlot!: HTMLSlotElement;
+
+  /**
+   * @private
+   * `slotchange` does not fire when text mutates inside an already-assigned
+   * element, which is how frameworks and runtime localisation set label text.
+   * `characterData` is needed to observe the text node itself changing.
+   */
+  readonly #labelMutationController = new MutationController(this, {
+    target: null,
+    config: { childList: true, subtree: true, characterData: true },
+    callback: () => this.#updateLabel(),
+  });
 
   /** @private */
   readonly #hintMutationController = new MutationController(this, {
@@ -838,6 +851,8 @@ export class M3eFormFieldElement extends ReconnectedCallback(AttachInternals(Lit
     this.#focusController.observe(this._base);
     this.#pressedController.observe(this._base);
 
+    this.#labelMutationController.observe(this._labelSlot);
+
     this.#hintMutationController.observe(this._hint);
     this.#handleHintChange();
 
@@ -847,9 +862,14 @@ export class M3eFormFieldElement extends ReconnectedCallback(AttachInternals(Lit
 
   /** @private */
   #handleLabelSlotChange(e: Event): void {
-    const assignedElements = (<HTMLSlotElement>e.target).assignedElements({ flatten: true });
-    setCustomState(this, "--with-label", assignedElements.length > 0);
-    this._pseudoLabel = getTextContent(<HTMLSlotElement>e.target);
+    this.#updateLabel(<HTMLSlotElement>e.target);
+  }
+
+  /** @private */
+  #updateLabel(slot: HTMLSlotElement | null = this._labelSlot): void {
+    if (!slot) return;
+    setCustomState(this, "--with-label", slot.assignedElements({ flatten: true }).length > 0);
+    this._pseudoLabel = getTextContent(slot);
   }
 
   /** @private */


### PR DESCRIPTION
## Description

`m3e-form-field` read its slotted label's text exactly once, in the label slot's
`slotchange` handler. Per spec, `slotchange` fires when a slot's assigned *nodes*
change — not when text mutates inside an already-assigned element. Any consumer
that inserts the label element and fills its text afterwards therefore left
`_pseudoLabel` permanently empty.

The outlined variant sizes its notch from a hidden `.pseudo-label` copy of that
string, so an empty value collapsed the notch to its 8px minimum,
`.outline-start` and `.outline-end` met, and their top borders drew straight
through the floating label.

This is easy to hit because template compilers make the ordering the default
rather than an edge case: they create the element in a creation pass and write
interpolated text in a later update pass. Runtime localisation is the same
mutation again, which is why the fix keeps observing rather than re-reading once
after startup — a notch sized for "E-mail" would otherwise stay that width when
the label becomes "Courriel".

**The change**

No new machinery was needed. `MutationController` already special-cases slot
targets: given an `HTMLSlotElement` it attaches a `slotchange` listener and then
observes each assigned element with the supplied config. So the fix is a
controller pointed at the label slot:

```ts
/** @private */ @query('slot[name="label"]') private readonly _labelSlot!: HTMLSlotElement;

readonly #labelMutationController = new MutationController(this, {
  target: null,
  config: { childList: true, subtree: true, characterData: true },
  callback: () => this.#updateLabel(),
});
```

plus `this.#labelMutationController.observe(this._labelSlot)` in `#initialize()`,
and `#handleLabelSlotChange` delegating to a new parameterless `#updateLabel()` so
a single read serves both the event and the observer.

`characterData` is the essential part — an in-place text update mutates a text
node's value rather than an element's child list. This mirrors the config
`m3e-badge` already uses for its own dynamic content, so the approach is
consistent with existing practice in the library rather than a new pattern.

One file, +26/−3. No public API change, no change to rendered markup or styles,
and no behavioural change for consumers that already set label text before
insertion.

## Related Issue

Fixes [#104](https://github.com/matraic/m3e/issues/104)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project

  `npm run lint` passes. The change reuses the existing controller idiom
  (`#hintMutationController` / `#errorMutationController`) and keeps the original
  `assignedElements({ flatten: true }).length > 0` check for the `--with-label`
  state so that behaviour is untouched.

- [x] I have performed a self-review of my code

- [ ] I have added tests that prove my fix/feature works (if applicable)

  Not applicable as far as I can tell — the repository has no test harness
  (no `test` script, no runner config, no spec files), so there was nowhere to
  add one. I validated externally instead and can port it to whatever harness you
  would prefer if you want coverage here. What I ran:

  1. **Framework-free reproduction, before/after.** Two fields differing only in
     when the label text is set:

     | build | text set **after** insert | text set **before** insert |
     |---|---|---|
     | 2.7.4 (published) | `_pseudoLabel: ""`, notch 8px | `"E-mail"`, notch 45.7px |
     | this branch | `"E-mail"`, notch 45.7px | `"E-mail"`, notch 45.7px |

     The unpatched control was re-run through the *same* harness afterwards, to
     confirm the difference was the fix and not the test's own settling logic.

  2. **Real application.** An Angular 21.2 app that had needed a workaround
     directive to repair the notch: with this branch installed and the workaround
     **removed**, the notch measures 45.7px and the label reads correctly across
     four theme modes (light, dark, light-medium-contrast, dark-high-contrast).
     With the published build and the workaround removed, it collapses to 8px.

  3. **Toolchain.** Root `npm run build` clean across `@m3e/web`, `@m3e/react` and
     `@m3e/icons`; `npm run lint` clean; `cem analyze` regenerates the manifest
     without complaint.

  The `pkg-pr-new` preview package this PR produces can be installed directly if
  you would like to reproduce (2) yourself.

- [ ] I have added necessary documentation (if applicable)

  Not applicable — no public API, attribute, slot or CSS custom property changed,
  so nothing in the component's README or manifest needed updating. The one
  non-obvious line (`characterData`) carries a short comment explaining why.

- [ ] Any dependent changes have been merged and published

  Not applicable — no dependent changes; the diff is confined to
  `packages/web/src/form-field/FormFieldElement.ts`.

## Screenshots (if applicable)

Two fields in the same application, neither using any workaround, differing only
in whether the label text is literal or bound:

- literal label → notch sized to the label, clean gap in the outline
- bound label → notch collapsed, top border struck through the label text

## Additional Notes

While tracing this I found the same pattern elsewhere, which you may want to
track separately — I have deliberately **not** included any of it here to keep the
diff to the reported bug:

**Same component.** The `hint` and `error` slots read through slots correctly
(`getTextContent(this._hint, true)` recurses into assigned nodes), but their
`MutationController`s observe the *shadow* `.hint` / `.error` elements, and
slotted light-DOM nodes are not descendants of those. In practice it is masked:
changing validity re-renders `${this._validationMessage}` inside the same shadow
span, which fires the observer, which then re-reads through the slot and happens
to pick up the new slotted text. Change the slotted text *without* a shadow
re-render — a language switch at constant validity — and `#errorText` /
`#hintText` go stale, so the `aria-describedby` description stops matching what is
on screen. Pointing those controllers at their slots as well would close it; I
have not built a reproduction, which is why it is not in this PR.

**Other components** that cache slotted text on `slotchange` with no mutation
observation:

| Component | Cached value feeds | Consequence if stale |
|---|---|---|
| `m3e-chip` | `.label`, and `.value` when `value` is unset | confirmed: `.value === ""` while the chip reads "Tractor" |
| `m3e-option` | `.label`, `.value`, `--empty` state | wrong `value`; affects `m3e-select` matching |
| `m3e-list-option` | `.label`, `.value` | same |
| `m3e-tooltip` | `#message` → `M3eAriaDescriber.describe()` | accessible description stale or empty |
| `m3e-rich-tooltip` | `#subheadText` → same describer path | same |

`m3e-badge` is not affected — it already observes its own light DOM with
`characterData: true`.

The `m3e-chip` entry is confirmed on 2.7.4, not just read from the source: with
the text set after insertion, `.label` and `.value` are both `""` while
`textContent` is `"Tractor"`. That is worse than a mis-drawn notch, since
selection state and submitted values silently disappear.

I am happy to extend this PR to apply slot observation across those components,
or to open follow-ups — whichever you prefer.
