### PR TITLE
fix(nav-bar): fit compact destinations within the bar at phone widths

### DIFF
--- a/packages/web/src/nav-bar/NavBarElement.ts
+++ b/packages/web/src/nav-bar/NavBarElement.ts
@@ -41,7 +41,8 @@ import { isNavBarMode, NavBarMode } from "./NavBarMode";
  *
  * @cssprop --m3e-nav-bar-height - Height of the navigation bar.
  * @cssprop --m3e-nav-bar-container-color - Background color of the navigation bar container.
- * @cssprop --m3e-nav-bar-vertical-item-width - Minimum width of vertical nav items.
+ * @cssprop --m3e-nav-bar-vertical-item-width - Minimum width a vertical nav item may shrink to. Defaults to the active indicator width, and never less than the 48px minimum touch target.
+ * @cssprop --m3e-nav-bar-horizontal-item-width - Minimum width of horizontal nav items.
  * @cssprop --m3e-nav-bar-horizontal-nav-item-leading-space - Leading space for horizontal nav items.
  * @cssprop --m3e-nav-bar-horizontal-nav-item-trailing-space - Trailing space for horizontal nav items.
  */
@@ -68,9 +69,22 @@ export class M3eNavBarElement extends ReconnectedCallback(AttachInternals(Role(L
       box-sizing: border-box;
       min-height: inherit;
       height: inherit;
-      width: 100%;
+
+      /* Size to the items' intrinsic minimum, but never narrower than the bar. Items divide the
+         bar equally while they fit; once even their minimum width cannot fit, the bar grows and
+         scrolls instead of painting items outside itself. */
+      width: min-content;
+      min-width: 100%;
+
       background-color: var(--m3e-nav-bar-container-color, ${DesignToken.color.surfaceContainer});
-      --_vertical-nav-item-min-width: var(--m3e-nav-bar-vertical-item-width, 112px);
+
+      /* The floor a vertical item may shrink to: the active indicator width, but never below the
+         48px minimum touch target. */
+      --_vertical-nav-item-min-width: var(
+        --m3e-nav-bar-vertical-item-width,
+        max(48px, var(--m3e-vertical-nav-item-active-indicator-width, 56px))
+      );
+      --_horizontal-nav-item-min-width: var(--m3e-nav-bar-horizontal-item-width, 112px);
       --_horizontal-nav-item-leading-space: var(
         --m3e-nav-bar-horizontal-nav-item-leading-space,
         ${DesignToken.measurement.space200}

--- a/packages/web/src/nav-bar/NavItemElement.ts
+++ b/packages/web/src/nav-bar/NavItemElement.ts
@@ -142,6 +142,7 @@ export class M3eNavItemElement extends SupportsDirectionality(
     }
     :host(:is(:state(--horizontal), :--horizontal)) {
       max-width: fit-content;
+      min-width: var(--_horizontal-nav-item-min-width);
     }
     :host(:is(:state(--horizontal), :--horizontal)) .outer {
       margin-inline-start: var(--_horizontal-nav-item-leading-space);
@@ -264,6 +265,8 @@ export class M3eNavItemElement extends SupportsDirectionality(
     }
     :host(:is(:state(--vertical), :--vertical)) .label {
       text-align: center;
+      /* Wrap a label too long for a narrow item rather than let it spill past the item. */
+      overflow-wrap: anywhere;
       display: -webkit-box;
       -webkit-line-clamp: 2;
       -webkit-box-orient: vertical;

--- a/packages/web/src/nav-bar/README.md
+++ b/packages/web/src/nav-bar/README.md
@@ -50,13 +50,35 @@ This section details the attributes, slots, events and CSS custom properties ava
 
 #### 🎛️ CSS Custom Properties
 
-| Property                                           | Description                              |
-| -------------------------------------------------- | ---------------------------------------- |
-| `--m3e-nav-bar-height`                             | Height of the navigation bar.            |
-| `--m3e-nav-bar-container-color`                    | Background color of the navigation bar.  |
-| `--m3e-nav-bar-vertical-item-width`                | Minimum width of vertical nav items.     |
-| `--m3e-nav-bar-horizontal-nav-item-leading-space`  | Leading space for horizontal nav items.  |
-| `--m3e-nav-bar-horizontal-nav-item-trailing-space` | Trailing space for horizontal nav items. |
+| Property                                           | Description                                                                                                    |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `--m3e-nav-bar-height`                             | Height of the navigation bar.                                                                                  |
+| `--m3e-nav-bar-container-color`                    | Background color of the navigation bar.                                                                        |
+| `--m3e-nav-bar-vertical-item-width`                | Minimum width a vertical (compact) item may shrink to. Defaults to the active indicator width, at least 48px. |
+| `--m3e-nav-bar-horizontal-item-width`              | Minimum width of a horizontal (expanded) item. Defaults to `7rem`.                                            |
+| `--m3e-nav-bar-horizontal-nav-item-leading-space`  | Leading space for horizontal nav items.                                                                       |
+| `--m3e-nav-bar-horizontal-nav-item-trailing-space` | Trailing space for horizontal nav items.                                                                      |
+
+## 📐 Fitting destinations to the bar
+
+The bar sizes its destinations to the space it has, so a bar with the supported 3-5 destinations
+fits within its own width at phone widths without any configuration.
+
+**Compact mode** (vertical items, the default) — items divide the bar's width equally. They shrink
+as the bar narrows, down to a floor of `--m3e-nav-bar-vertical-item-width`, which defaults to the
+active indicator width (`3.5rem`) and is never less than the 48px minimum touch target. A label too
+long for a narrow item wraps, up to two lines; beyond that it is clipped. Five destinations
+therefore fit inside a 320px-wide bar (64px each) and remain fully tappable.
+
+**Expanded mode** (horizontal items) — items are sized to their content, with a minimum of
+`--m3e-nav-bar-horizontal-item-width` (`7rem`), and the set is centred in the bar. Because a
+horizontal label is not wrapped or truncated, a set of long labels can need more width than a phone
+provides. In that case the bar scrolls horizontally rather than painting destinations outside
+itself, so every destination stays reachable. Prefer `mode="auto"`, which selects compact
+presentation at compact widths and avoids the scroll.
+
+In both modes the bar never renders a destination outside its own box: it either fits the
+destinations or scrolls them.
 
 ### 🗂️ m3e-nav-item
 


### PR DESCRIPTION
## Description

At phone widths, compact (vertical) nav destinations could spill outside the bar instead of fitting within it. This PR makes the bar fit its destinations to the space it has, so the supported 3–5 destinations fit within the bar's own width without configuration, and the bar scrolls rather than painting items outside itself when they genuinely cannot fit.

**Before:** `m3e-nav-bar`'s inner layout was fixed at `width: 100%` and every vertical item was held to a `7rem` minimum width. With 4–5 compact destinations on a ~320px-wide phone, the items' combined minimum exceeded the bar and painted outside its box. Long labels overflowed their item.

**After:**

- The bar sizes to its items' intrinsic minimum (`width: min-content`) but never narrower than the bar itself (`min-width: 100%`). Items divide the bar equally while they fit; once even their minimum can't fit, the bar grows and scrolls (the host already has `overflow-x`) instead of overflowing.
- A vertical item's shrink floor is now the active-indicator width (`--m3e-vertical-nav-item-active-indicator-width`, default `56px`), clamped so it is never below the `48px` minimum touch target — `max(48px, …)`. Five destinations therefore fit inside a 320px bar (~64px each) and stay fully tappable.
- Long vertical labels wrap (`overflow-wrap: anywhere`, still clamped to two lines) instead of spilling past the item.
- A new `--m3e-nav-bar-horizontal-item-width` custom property sets the minimum width of horizontal (expanded) items (default `7rem` / `112px`).

The `nav-bar` README gains a **"Fitting destinations to the bar"** section documenting the compact vs. expanded behavior and the new property.

### New CSS custom property

| Property                          | Description                                                                                     |
| --------------------------------- | ---------------------------------------------------------------------------------------------- |
| `--m3e-nav-bar-horizontal-item-width` | Minimum width of a horizontal (expanded) nav item. Defaults to `7rem`.                     |

The existing `--m3e-nav-bar-vertical-item-width` is unchanged in name; its default is now the active-indicator width (at least 48px) rather than a fixed `7rem`, so compact items can shrink enough to fit.

## Related Issue

No linked issue.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [x] I have added necessary documentation (if applicable)
- [ ] Any dependent changes have been merged and published

## Additional Notes

- This branch was rebased onto current `main`, which had refactored `NavItemElement` to drive orientation styling from custom states (`:state(--vertical|--horizontal)`) and to use a selection indicator. The fix was re-expressed on top of that refactor: it reuses the current `--_vertical-nav-item-min-width` / `--_horizontal-nav-item-min-width` internal variables and matches the current px unit convention.
- One resolution worth a maintainer's eye: current `main` intentionally dropped the horizontal item minimum width in favor of leading/trailing space tokens. This PR reintroduces a horizontal minimum via the new `--m3e-nav-bar-horizontal-item-width` (default `7rem`, restoring the pre-refactor floor). If you'd prefer horizontal items to remain purely content-sized, set the property to `0` — or let me know and I'll drop that part.
- `pnpm build` (rollup) and `pnpm lint` (eslint) both pass in `packages/web`. No tracked custom-elements manifest exists to regenerate (`cem` output is a `dist/` build artifact).
