### PR TITLE
fix(icon): notify every observer when an icon is registered

### DIFF
--- a/packages/web/src/icon/IconRegistry.ts
+++ b/packages/web/src/icon/IconRegistry.ts
@@ -67,7 +67,8 @@ export class IconRegistry {
       filled: svg`<svg viewBox="${fillSet.filled.viewBox}"><path d="${fillSet.filled.path}"/></svg>`,
     });
 
-    this.#observers.get(key)?.forEach((x) => x());
+    const observers = this.#observers.get(key);
+    observers?.slice().forEach((x) => x());
   }
 
   /**


### PR DESCRIPTION
## Description

Fixes #117: when several `<m3e-icon>` elements await the same not-yet-registered icon, only every other one renders it. The rest stay on the text fallback permanently, showing the raw icon name.

`IconRegistry.addIcon` notified observers by iterating the live array, while each observer unsubscribes itself from that same array inside its own callback (`M3eIconElement` does exactly this). The splice shifts every following entry down one index, and `forEach` — which advances by index — skips whichever observer moved into the slot it just visited. Skipped elements never recover, since `willUpdate` only re-subscribes when `name` itself changes.

The fix iterates a copy:

```diff
-    this.#observers.get(key)?.forEach((x) => x());
+    const observers = this.#observers.get(key);
+    observers?.slice().forEach((x) => x());
```

Two lines, one file, no API or behaviour change beyond the observers that were being dropped.

## Related Issue

Fixes https://github.com/matraic/m3e/issues/117

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works (if applicable) — the repo has no test runner configured; the reproduction below is the evidence, and I am glad to add it as a test if you point me at a harness
- [ ] I have added necessary documentation (if applicable) — not applicable; the fix is two lines at the call site and the reasoning lives in #117
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A — the console output below is the clearest form.

## Verification

The reproduction from #117 — five `<m3e-icon>` elements naming one icon that is registered a frame later — bundled straight from source and run both ways:

| build | result |
| ------------------------ | ---------------------------------------- |
| `main` (`094186f8`, 2.7.10) | `["svg", "text", "svg", "text", "svg"]` |
| this branch | `["svg", "svg", "svg", "svg", "svg"]` |

Chromium 151.0.7922.34 on Linux, vanilla JS, no framework involved. `npm run lint` and `npm run build` pass for `@m3e/web`.

## Additional Notes